### PR TITLE
I wanted to add a course

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -59,6 +59,7 @@ function createNotFoundPage(dir, options, logger) {
             'CS-446-Machine-Learning',
             'CS-461-Computer-Security-I',
             'CS-475-Formal-Models-of-Computation',
+            'CS-591-CS-Colloquium',
         ]
         const directory = path.join(dir, 'courses')
         logger.info(`directory = ${directory}`)

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -35,4 +35,8 @@
 <url><loc>https://uiucmcs.org/courses/CS-525-Advanced-Distributed-Systems</loc><lastmod>2022-03-16T11:10:10+00:00</lastmod></url>
 <url><loc>https://uiucmcs.org/courses/CS-598-Advanced-Bayesian-Modeling</loc><lastmod>2022-03-16T11:10:10+00:00</lastmod></url>
 <url><loc>https://uiucmcs.org/courses/CS-463-Computer-Security-II</loc><lastmod>2022-11-16T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-446-Machine-Learning</loc><lastmod>2022-11-16T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-461-Computer-Security-I</loc><lastmod>2022-11-16T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-475-Formal-Models-of-Computation</loc><lastmod>2022-11-16T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-591-CS-Colloquium</loc><lastmod>2022-11-16T11:10:10+00:00</lastmod></url>
 </urlset>


### PR DESCRIPTION
A new course has been added to the Online MCS/MCS-DS Fall 2025 schedule:

Course: CS 591 Advanced Seminar - CS Colloquium, CRN 35937, Section CSO

Credit Hours: 1

Grading: S/U only

Instructors: Dr. Nancy Amato and Dr. Lawrence Rauchwerger

Course Description and Goals: The purpose of the course is to expose you to a broad range of current research topics in computer science and related fields through attending research seminars offered in the Siebel School of Computing and Data Science. It is useful for you to attend even when the topic seems unrelated to your interest or research - indeed, seminars provide the best way for you to round out your knowledge by exposing you to current research in areas that are not directly related to your own research. Seminars will generally be held on Mondays and/or Wednesdays. Students should check the department calendar at https://cs.illinois.edu/calenda or the Inside CS Weekly Digest that comes out each Sunday for current listing of talks.

Mechanics and Grading: To receive credit for this course you must attend and satisfactorily complete a report for at least 14 eligible research seminars during the semester.  The reports should be submitted by the last day of the final exam period, or December 19, 2025.

https://courses.grainger.illinois.edu/cs591up/fa2025/