### PR TITLE
feat: adds planner tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 Original code forked from [MSCSHub](https://github.com/MSCSHub/MSCSHub).
 
+The course planner feature is based on [UIUC MCS Course Planner](https://github.com/uiucmcs/courseplanner) by UIUC MCS Community, licensed under the MIT License.
+
 ## License
 
 This project is licensed under the [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.html).
+
+Third-party licenses can be found in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,36 @@
+# Third Party Licenses
+
+This project includes code from the following third-party projects:
+
+## UIUC MCS Course Planner
+
+The planner feature (`src/app/planner/`) is based on the UIUC MCS Course Planner project.
+
+- **Project**: UIUC MCS Course Planner
+- **Repository**: https://github.com/uiucmcs/courseplanner
+- **Copyright**: Copyright (c) 2021 UIUC MCS Community
+- **License**: MIT License
+
+### MIT License
+
+MIT License
+
+Copyright (c) 2021 UIUC MCS Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/angular.json
+++ b/angular.json
@@ -133,8 +133,13 @@
                         ],
                         "styles": [
                             "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-                            "src/styles.scss"
+                            "src/styles/main.scss"
                         ],
+                        "stylePreprocessorOptions": {
+                            "includePaths": [
+                                "./src/styles/"
+                            ]
+                        },
                         "scripts": []
                     }
                 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,18 @@
         "@angular-devkit/build-angular": "^20.3.4",
         "@angular/cli": "^20.3.4",
         "@angular/compiler-cli": "^20.3.3",
+        "@stryker-mutator/core": "^9.3.0",
+        "@stryker-mutator/karma-runner": "^9.3.0",
+        "@stryker-mutator/typescript-checker": "^9.3.0",
+        "@types/jasmine": "^5.1.12",
         "@types/randomcolor": "^0.5.9",
-        "angular-cli-ghpages": "^2.0.3"
+        "angular-cli-ghpages": "^2.0.3",
+        "jasmine-core": "^5.12.1",
+        "karma": "^6.4.4",
+        "karma-chrome-launcher": "^3.2.0",
+        "karma-coverage": "^2.2.1",
+        "karma-jasmine": "^5.1.0",
+        "karma-jasmine-html-reporter": "^2.1.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -332,6 +342,48 @@
         }
       }
     },
+    "node_modules/@angular-devkit/architect/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@angular-devkit/architect/node_modules/jsonc-parser": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
@@ -347,6 +399,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -767,6 +849,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -778,6 +887,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/is-interactive": {
@@ -868,6 +992,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -1697,18 +1851,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
-      "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
+      "integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.27.1",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.3",
+        "@babel/traverse": "^7.28.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1784,14 +1938,14 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1926,9 +2080,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1975,13 +2129,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2074,12 +2228,46 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.28.0.tgz",
+      "integrity": "sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-decorators": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz",
+      "integrity": "sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2107,6 +2295,38 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
       "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2956,6 +3176,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
+      "integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.5",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -3133,6 +3373,26 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
@@ -3159,36 +3419,63 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/generator": "^7.28.5",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.28.5",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/types": "^7.28.5",
         "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6775,6 +7062,13 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sigstore/bundle": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.1.0.tgz",
@@ -6854,6 +7148,198 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.3.0.tgz",
+      "integrity": "sha512-X6riRHxJiPC2Pp4uxBkol+9MJpZMmX+OuZEttPEuucbY3JgnEv2zxlQ4TMrUaHPuhbsqoQx+mCEB24UVDJDc8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.5.1",
+        "mutation-testing-report-schema": "3.5.1",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.3.0.tgz",
+      "integrity": "sha512-VgF7kyUcCyyrVYCvY4DUIsB7KdhY+IvvjN+bD2rPD8wPNLV//9crDzbPvrX1/pgTnMS3NuEzE0Tj/6MxdoEg+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^7.0.0",
+        "@stryker-mutator/api": "9.3.0",
+        "@stryker-mutator/instrumenter": "9.3.0",
+        "@stryker-mutator/util": "9.3.0",
+        "ajv": "~8.17.1",
+        "chalk": "~5.4.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.4.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.0.0",
+        "mutation-server-protocol": "~0.3.0",
+        "mutation-testing-elements": "3.5.3",
+        "mutation-testing-metrics": "3.5.1",
+        "mutation-testing-report-schema": "3.5.1",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.1.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.3.0.tgz",
+      "integrity": "sha512-icNSrNM/dDmegtkqKnaCd7sijp27g37rjFmhssYJwK9SGdgygLtV9J02hVS5W6cFnAGnCI0dSSRyj7I1BeAA3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.28.0",
+        "@babel/generator": "~7.28.0",
+        "@babel/parser": "~7.28.0",
+        "@babel/plugin-proposal-decorators": "~7.28.0",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/preset-typescript": "~7.28.0",
+        "@stryker-mutator/api": "9.3.0",
+        "@stryker-mutator/util": "9.3.0",
+        "angular-html-parser": "~9.2.0",
+        "semver": "~7.7.0",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/karma-runner": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/karma-runner/-/karma-runner-9.3.0.tgz",
+      "integrity": "sha512-b8zeXs8/kAVbE6KGIB3uEXusEl3WkQ4J7RGSSW7rZvvIDTi8JtFK6WdQzlcRvzluREchZ7Mp0AO9xHikupOLSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.3.0",
+        "@stryker-mutator/util": "9.3.0",
+        "decamelize": "~6.0.0",
+        "semver": "~7.7.0",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.3.0"
+      }
+    },
+    "node_modules/@stryker-mutator/typescript-checker": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-9.3.0.tgz",
+      "integrity": "sha512-1ec0p2p9DqG6+6qy2Odhwjev8FuB/63k8YxCDUtiKKR6sozSFSyLl1s6n2ZKwxhK+xJXiSKo3+OSf529VzuOpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.3.0",
+        "@stryker-mutator/util": "9.3.0",
+        "semver": "~7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.3.0",
+        "typescript": ">=3.6"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.3.0.tgz",
+      "integrity": "sha512-+garjSeH1WFC/UrRnWrOds3fugqT0MqMb5N1V/Zh5fMXZvBroZ7vq1abXR2zPZ7YdzVJ4P8XgLB+itPS65k27w==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
@@ -6947,6 +7433,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -7018,6 +7514,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.12.tgz",
+      "integrity": "sha512-1BzPxNsFDLDfj9InVR3IeY0ZVf4o9XV+4mDqoCfyPkbsA7dYyKAPAb2co6wLFlHcvxPlt1wShm7zQdV7uTfLGA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7565,6 +8068,48 @@
         }
       }
     },
+    "node_modules/angular-cli-ghpages/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/angular-cli-ghpages/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/angular-cli-ghpages/node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
@@ -7578,6 +8123,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/angular-cli-ghpages/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/angular-cli-ghpages/node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/angular-cli-ghpages/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -7586,6 +8161,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/angular-html-parser": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-9.2.0.tgz",
+      "integrity": "sha512-jfnGrA5hguEcvHPrHUsrWOs8jk6SE9cQzFHxt3FPGwzvSEBXLAawReXylh492rzz5km5VgR664EUDMNnmYstSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-colors": {
@@ -7860,6 +8445,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.12",
@@ -8575,6 +9170,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
@@ -8583,6 +9194,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -8828,6 +9508,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/custom-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8844,6 +9541,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-browser": {
@@ -8912,6 +9622,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8941,6 +9662,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -8952,6 +9687,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -9107,6 +9855,124 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -9120,6 +9986,29 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/ent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
+      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "punycode": "^1.4.1",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ent/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -9416,6 +10305,46 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -9481,6 +10410,13 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9579,6 +10515,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -9720,6 +10672,13 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -9923,6 +10882,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gh-pages": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
@@ -10114,6 +11090,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -10195,6 +11187,13 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -10335,6 +11334,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/hyperdyperid": {
@@ -10702,6 +11711,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -10743,6 +11784,19 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10788,6 +11842,89 @@
         "node": ">=10"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -10803,6 +11940,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/jasmine-core": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.12.1.tgz",
+      "integrity": "sha512-P/UbRZ0LKwXe7wEpwDheuhunPwITn4oPALhrJEQJo6756EwNGnsK/TSQrWojBB4cQDQ+VaxWYws9tFNDuiMh2Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -10828,6 +11972,13 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10871,6 +12022,13 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -10920,6 +12078,148 @@
       ],
       "license": "MIT"
     },
+    "node_modules/karma": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
+      "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "body-parser": "^1.19.0",
+        "braces": "^3.0.2",
+        "chokidar": "^3.5.1",
+        "connect": "^3.7.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.1",
+        "glob": "^7.1.7",
+        "graceful-fs": "^4.2.6",
+        "http-proxy": "^1.18.1",
+        "isbinaryfile": "^4.0.8",
+        "lodash": "^4.17.21",
+        "log4js": "^6.4.1",
+        "mime": "^2.5.2",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
+        "qjobs": "^1.2.0",
+        "range-parser": "^1.2.1",
+        "rimraf": "^3.0.2",
+        "socket.io": "^4.7.2",
+        "source-map": "^0.6.1",
+        "tmp": "^0.2.1",
+        "ua-parser-js": "^0.7.30",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "karma": "bin/karma"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/karma-chrome-launcher": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.2.0.tgz",
+      "integrity": "sha512-rE9RkUPI7I9mAxByQWkGJFXfFD6lE4gC5nPuZdobf/QdTEJI6EU4yIay/cfU/xV4ZxlM5JiTv7zWYgA64NpS5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which": "^1.2.1"
+      }
+    },
+    "node_modules/karma-chrome-launcher/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/karma-coverage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-2.2.1.tgz",
+      "integrity": "sha512-yj7hbequkQP2qOSb20GuNSIyE//PgJWHwC2IydLE6XRtsnaflv+/OSGNssPjobYUlhVVagy99TQpqUt3vAUG7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.0.5",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma-coverage/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/karma-jasmine": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
+      "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jasmine-core": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "karma": "^6.0.0"
+      }
+    },
+    "node_modules/karma-jasmine-html-reporter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-2.1.0.tgz",
+      "integrity": "sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "jasmine-core": "^4.0.0 || ^5.0.0",
+        "karma": "^6.0.0",
+        "karma-jasmine": "^5.0.0"
+      }
+    },
+    "node_modules/karma-jasmine/node_modules/jasmine-core": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
+      "integrity": "sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz",
@@ -10928,6 +12228,370 @@
       "license": "MIT",
       "dependencies": {
         "source-map-support": "^0.5.5"
+      }
+    },
+    "node_modules/karma/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/karma/node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/karma/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/karma/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/karma/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/karma/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/karma/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/karma/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/karma/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/karma/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/karma/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/karma/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/karma/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/karma/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/kind-of": {
@@ -11205,6 +12869,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -11302,6 +12973,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log4js": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/long": {
@@ -11584,6 +13272,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -11814,6 +13512,43 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.3.0.tgz",
+      "integrity": "sha512-pQY+lb80vuD33P1NwhDyCWUgwP2w6JAP5+9Hz3CWM2HpIoYxDkT7OXYKabaunKnoSCgutP3MuruzPCXxLX/lnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.5.3.tgz",
+      "integrity": "sha512-Vr76a77/mFGsiSAUL+1xFEDb3n5lFs7UJKGWHtaJ+C85kutpBU3QVQ88zobo8Y0dNZPgcMrfThjOzp7W4nmLlQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.5.1.tgz",
+      "integrity": "sha512-mNgEcnhyBDckgoKg1kjG/4Uo3aBCW0WdVUxINVEazMTggPtqGfxaAlQ9GjItyudu/8S9DuspY3xUaIRLozFG9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.5.1"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.5.1.tgz",
+      "integrity": "sha512-tu5ATRxGH3sf2igiTKonxlCsWnWcD3CYr3IXGUym7yTh3Mj5NoJsu7bDkJY99uOrEp6hQByC2nRUPEGfe6EnAg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
@@ -12232,6 +13967,36 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -12569,6 +14334,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
@@ -13023,6 +14801,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -13039,6 +14833,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
@@ -13108,6 +14912,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qjobs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.9"
       }
     },
     "node_modules/qs": {
@@ -13426,6 +15240,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
@@ -13560,6 +15391,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -14064,6 +15913,173 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -14284,6 +16300,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/streamroller": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/streamroller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/streamroller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -14404,6 +16470,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-outer": {
@@ -14652,6 +16731,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -14736,6 +16825,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -14758,6 +16857,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -14772,6 +16898,40 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.14.0",
@@ -14821,6 +16981,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unique-filename": {
@@ -15060,6 +17233,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -15101,6 +17284,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/web-vitals": {
       "version": "4.2.4",
@@ -16105,6 +18295,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "start": "ng serve",
     "build": "ng build",
+    "test": "ng test",
+    "test:headless": "ng test --browsers=ChromeHeadless --watch=false --code-coverage",
+    "test:mutation": "stryker run",
     "deploy": "ng deploy --no-nojekyll && gh-pages -d dist/uiuc-mcs-org -r git@github.com:uiuc-mcs/uiuc-mcs.git -p 4 -t",
     "deploy-uiuc-mcs": "ng build --configuration=uiuc-mcs && ng deploy --base-href=https://uiucmcs.org --cname=uiucmcs.org --repo=git@github.com:uiuc-mcs/uiuc-mcs.git --no-build"
   },
@@ -27,7 +30,17 @@
     "@angular-devkit/build-angular": "^20.3.4",
     "@angular/cli": "^20.3.4",
     "@angular/compiler-cli": "^20.3.3",
+    "@stryker-mutator/core": "^9.3.0",
+    "@stryker-mutator/karma-runner": "^9.3.0",
+    "@stryker-mutator/typescript-checker": "^9.3.0",
+    "@types/jasmine": "^5.1.12",
     "@types/randomcolor": "^0.5.9",
-    "angular-cli-ghpages": "^2.0.3"
+    "angular-cli-ghpages": "^2.0.3",
+    "jasmine-core": "^5.12.1",
+    "karma": "^6.4.4",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage": "^2.2.1",
+    "karma-jasmine": "^5.1.0",
+    "karma-jasmine-html-reporter": "^2.1.0"
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ import { environment } from 'src/environments/environment'
 
 import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
 import { CourseChartComponent } from './courses/course-chart/course-chart.component';
+import { PlannerComponent } from './planner/components/planner.component';
 
 export interface NavItem {
     title: string,
@@ -32,6 +33,7 @@ export const NavInfo = new Map<string, NavItem>([
     ['courses', { title: 'Courses', url: '/', show: true }],
     ['grid', { title: 'Grid', url: '/grid', show: true }],
     ['chart', { title: 'Chart', url: '/chart', show: true }],
+    ['planner', { title: 'Planner', url: '/planner', show: true }],
     ['reviews', { title: 'Reviews', url: '/reviews', show: true }],
     ['createReview', { title: 'Create Review', url: '/createReview', show: false }],
     ['settings', { title: 'Profile', url: '/settings', show: false }],
@@ -87,6 +89,10 @@ const routes: Routes = [
     {
         path: 'chart', component: CourseChartComponent,
         data: { title: `Course Chart | ${environment.websiteName}`, description: '' }
+    },
+    {
+        path: 'planner', component: PlannerComponent,
+        data: { title: `Course Planner | ${environment.websiteName}`, description: '' }
     },
     {
         path: 'reviews', component: ReviewsComponent,

--- a/src/app/navigation/navbar/navbar.component.html
+++ b/src/app/navigation/navbar/navbar.component.html
@@ -18,6 +18,11 @@
           </a>
         </li>
         <li class="fxhide-lt-xs">
+          <a class="nav-link" routerLink="{{navInfo.get('planner')!.url}}" [title]="navInfo.get('planner')!.title">
+            <span class="nav-link-inner">{{ navInfo.get('planner')!.title }}</span>
+          </a>
+        </li>
+        <li class="fxhide-lt-xs">
           <a class="nav-link" routerLink="{{navInfo.get('reviews')!.url}}" [title]="navInfo.get('reviews')!.title">
             <span class="nav-link-inner">{{ navInfo.get('reviews')!.title }}</span>
           </a>

--- a/src/app/planner/components/category-browser.component.spec.ts
+++ b/src/app/planner/components/category-browser.component.spec.ts
@@ -1,0 +1,309 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange } from '@angular/core';
+import { CategoryBrowserComponent } from './category-browser.component';
+import { CourseDataService } from '../services/course-data.service';
+
+describe('CategoryBrowserComponent', () => {
+  let component: CategoryBrowserComponent;
+  let fixture: ComponentFixture<CategoryBrowserComponent>;
+  let courseDataService: CourseDataService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CategoryBrowserComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CategoryBrowserComponent);
+    component = fixture.componentInstance;
+    courseDataService = TestBed.inject(CourseDataService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with empty selectedCourseIds', () => {
+      expect(component.selectedCourseIds).toBeDefined();
+      expect(Array.isArray(component.selectedCourseIds)).toBe(true);
+    });
+
+    it('should initialize displayCategories', () => {
+      expect(component.displayCategories).toBeDefined();
+      expect(Array.isArray(component.displayCategories)).toBe(true);
+    });
+
+    it('should build category display on initialization', () => {
+      expect(component.displayCategories.length).toBeGreaterThan(0);
+    });
+
+    it('should have requirement categories with correct structure', () => {
+      component.displayCategories.forEach(reqDisplay => {
+        expect(reqDisplay.reqName).toBeDefined();
+        expect(Array.isArray(reqDisplay.categories)).toBe(true);
+      });
+    });
+
+    it('should have categories with required properties', () => {
+      component.displayCategories.forEach(reqDisplay => {
+        reqDisplay.categories.forEach(cat => {
+          expect(cat.id).toBeDefined();
+          expect(cat.name).toBeDefined();
+          expect(Array.isArray(cat.courses)).toBe(true);
+          expect(Array.isArray(cat.selectedIds)).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('ngOnChanges', () => {
+    it('should update selected courses when selectedCourseIds change', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        component.selectedCourseIds = [courseId];
+        
+        component.ngOnChanges({
+          selectedCourseIds: new SimpleChange([], [courseId], false)
+        });
+
+        // Check if the course is marked as selected in the appropriate category
+        let foundSelected = false;
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            if (cat.selectedIds.includes(courseId)) {
+              foundSelected = true;
+            }
+          });
+        });
+        expect(foundSelected).toBe(true);
+      }
+    });
+
+    it('should not update if selectedCourseIds did not change', () => {
+      const initialDisplayCategories = component.displayCategories;
+      component.ngOnChanges({});
+      expect(component.displayCategories).toBe(initialDisplayCategories);
+    });
+
+    it('should handle empty selectedCourseIds', () => {
+      component.selectedCourseIds = [];
+      component.ngOnChanges({
+        selectedCourseIds: new SimpleChange([['course1']], [], false)
+      });
+
+      component.displayCategories.forEach(reqDisplay => {
+        reqDisplay.categories.forEach(cat => {
+          expect(cat.selectedIds.length).toBe(0);
+        });
+      });
+    });
+
+    it('should handle multiple selected courses', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length >= 2) {
+        const courseIds = [courses[0].id, courses[1].id];
+        component.selectedCourseIds = courseIds;
+        
+        component.ngOnChanges({
+          selectedCourseIds: new SimpleChange([], courseIds, false)
+        });
+
+        let selectedCount = 0;
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            selectedCount += cat.selectedIds.length;
+          });
+        });
+        
+        // At least some courses should be selected
+        expect(selectedCount).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe('buildCategoryDisplay', () => {
+    it('should create display categories from course data', () => {
+      const courseData = courseDataService.getCourseData();
+      expect(component.displayCategories.length).toBe(courseData.requirements.req.length);
+    });
+
+    it('should populate courses for each category', () => {
+      component.displayCategories.forEach(reqDisplay => {
+        reqDisplay.categories.forEach(cat => {
+          // Categories should have courses (or at least an empty array)
+          expect(Array.isArray(cat.courses)).toBe(true);
+        });
+      });
+    });
+
+    it('should match requirement names from course data', () => {
+      const courseData = courseDataService.getCourseData();
+      const reqNames = courseData.requirements.req.map(r => r.name);
+      const displayReqNames = component.displayCategories.map(d => d.reqName);
+      
+      reqNames.forEach(name => {
+        expect(displayReqNames).toContain(name);
+      });
+    });
+
+    it('should create correct number of categories per requirement', () => {
+      const courseData = courseDataService.getCourseData();
+      
+      for (let i = 0; i < courseData.requirements.req.length; i++) {
+        const req = courseData.requirements.req[i];
+        const display = component.displayCategories[i];
+        expect(display.categories.length).toBe(req.categories.length);
+      }
+    });
+  });
+
+  describe('updateSelectedCourses', () => {
+    it('should mark courses as selected based on selectedCourseIds', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const course = courses[0];
+        component.selectedCourseIds = [course.id];
+        component['updateSelectedCourses']();
+
+        let foundSelected = false;
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            if (cat.courses.find(c => c.id === course.id)) {
+              expect(cat.selectedIds).toContain(course.id);
+              foundSelected = true;
+            }
+          });
+        });
+      }
+    });
+
+    it('should clear selected IDs when no courses selected', () => {
+      component.selectedCourseIds = [];
+      component['updateSelectedCourses']();
+
+      component.displayCategories.forEach(reqDisplay => {
+        reqDisplay.categories.forEach(cat => {
+          expect(cat.selectedIds.length).toBe(0);
+        });
+      });
+    });
+
+    it('should only mark courses in correct categories as selected', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const course = courses[0];
+        component.selectedCourseIds = [course.id];
+        component['updateSelectedCourses']();
+
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            const hasCourse = cat.courses.some(c => c.id === course.id);
+            const isSelected = cat.selectedIds.includes(course.id);
+            
+            if (hasCourse) {
+              expect(isSelected).toBe(true);
+            } else {
+              expect(isSelected).toBe(false);
+            }
+          });
+        });
+      }
+    });
+  });
+
+  describe('Category display structure', () => {
+    it('should display all requirement categories', () => {
+      const courseData = courseDataService.getCourseData();
+      expect(component.displayCategories.length).toBe(courseData.requirements.req.length);
+    });
+
+    it('should include courses from course data service', () => {
+      const courseData = courseDataService.getCourseData();
+      
+      component.displayCategories.forEach((reqDisplay, i) => {
+        const req = courseData.requirements.req[i];
+        
+        reqDisplay.categories.forEach((cat, j) => {
+          const categoryId = req.categories[j].id;
+          const expectedCourses = courseDataService.getCategoryCourses(categoryId);
+          expect(cat.courses.length).toBe(expectedCourses.length);
+        });
+      });
+    });
+
+    it('should maintain category IDs correctly', () => {
+      const courseData = courseDataService.getCourseData();
+      
+      component.displayCategories.forEach((reqDisplay, i) => {
+        const req = courseData.requirements.req[i];
+        
+        reqDisplay.categories.forEach((cat, j) => {
+          expect(cat.id).toBe(req.categories[j].id);
+        });
+      });
+    });
+  });
+
+  describe('Course selection tracking', () => {
+    it('should track no selections initially', () => {
+      let totalSelected = 0;
+      component.displayCategories.forEach(reqDisplay => {
+        reqDisplay.categories.forEach(cat => {
+          totalSelected += cat.selectedIds.length;
+        });
+      });
+      expect(totalSelected).toBe(0);
+    });
+
+    it('should track course selections across multiple categories', () => {
+      const courses = courseDataService.getCourseData().courses;
+      // Find courses that belong to multiple categories
+      const multiCategoryCourse = courses.find(c => c.category.length > 1);
+      
+      if (multiCategoryCourse) {
+        component.selectedCourseIds = [multiCategoryCourse.id];
+        component['updateSelectedCourses']();
+
+        let categoryCount = 0;
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            if (cat.selectedIds.includes(multiCategoryCourse.id)) {
+              categoryCount++;
+            }
+          });
+        });
+
+        // Should be selected in all matching categories
+        expect(categoryCount).toBeGreaterThan(0);
+      }
+    });
+
+    it('should handle deselection', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        
+        // First select
+        component.selectedCourseIds = [courseId];
+        component['updateSelectedCourses']();
+        
+        // Then deselect
+        component.selectedCourseIds = [];
+        component['updateSelectedCourses']();
+
+        let foundSelected = false;
+        component.displayCategories.forEach(reqDisplay => {
+          reqDisplay.categories.forEach(cat => {
+            if (cat.selectedIds.includes(courseId)) {
+              foundSelected = true;
+            }
+          });
+        });
+        expect(foundSelected).toBe(false);
+      }
+    });
+  });
+});

--- a/src/app/planner/components/category-browser.component.ts
+++ b/src/app/planner/components/category-browser.component.ts
@@ -1,0 +1,204 @@
+/**
+ * Based on UIUC MCS Course Planner (https://github.com/uiucmcs/courseplanner)
+ * Copyright (c) 2021 UIUC MCS Community
+ * Licensed under the MIT License
+ */
+
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CourseDataService, Course, RequirementCategory } from '../services/course-data.service';
+
+interface CategoryDisplay {
+  reqName: string;
+  categories: Array<{
+    id: string;
+    name: string;
+    courses: Course[];
+    selectedIds: string[];
+  }>;
+}
+
+@Component({
+  selector: 'app-category-browser',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="category-browser">
+      <h2>Requirement Categories</h2>
+
+      <div class="requirements-section" *ngFor="let req of displayCategories; let i = index">
+        <h3>{{ req.reqName }}</h3>
+
+        <div class="categories-grid">
+          <div class="category-item" *ngFor="let cat of req.categories">
+            <h4>{{ cat.name }}</h4>
+            <div class="courses-list">
+              <div class="course"
+                   *ngFor="let course of cat.courses"
+                   [class.selected]="cat.selectedIds.includes(course.id)">
+                <span class="code">{{ course.code }}</span>
+                <span class="name">{{ course.name }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="clear: both;"></div>
+    </div>
+  `,
+  styles: [`
+    .category-browser {
+      padding: 20px;
+      background: #f9f9f9;
+      border-radius: 8px;
+      margin-bottom: 30px;
+
+      h2 {
+        margin-top: 0;
+        color: #333;
+        border-bottom: 2px solid #1976d2;
+        padding-bottom: 10px;
+      }
+    }
+
+    .requirements-section {
+      margin-bottom: 30px;
+
+      h3 {
+        color: #1976d2;
+        margin: 20px 0 15px 0;
+        font-size: 16px;
+      }
+    }
+
+    .requirements-section:nth-of-type(2),
+    .requirements-section:nth-of-type(3) {
+      display: inline-block;
+      
+      margin-right: 16px;
+      vertical-align: top;
+    }
+
+    .requirements-section:nth-of-type(3) {
+      margin-right: 0;
+    }
+
+    .categories-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: 15px;
+    }
+
+    .category-item {
+      background: white;
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      padding: 15px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+
+      h4 {
+        margin: 0 0 10px 0;
+        color: #333;
+        font-size: 14px;
+        font-weight: 600;
+      }
+    }
+
+    .courses-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .course {
+      display: flex;
+      gap: 8px;
+      padding: 8px;
+      background: #f5f5f5;
+      border-radius: 4px;
+      border-left: 3px solid #ccc;
+      transition: all 0.2s;
+
+      &.selected {
+        background: #e8f4fd;
+        border-left-color: #4caf50;
+
+        .code {
+          color: #4caf50;
+          font-weight: 700;
+        }
+      }
+
+      &:hover {
+        background: #f0f0f0;
+      }
+
+      .code {
+        font-weight: 600;
+        color: #1976d2;
+        min-width: 60px;
+        font-size: 12px;
+      }
+
+      .name {
+        font-size: 12px;
+        color: #555;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  `]
+})
+export class CategoryBrowserComponent implements OnChanges {
+  @Input() selectedCourseIds: string[] = [];
+
+  displayCategories: CategoryDisplay[] = [];
+
+  constructor(private courseDataService: CourseDataService) {
+    this.buildCategoryDisplay();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['selectedCourseIds']) {
+      this.updateSelectedCourses();
+    }
+  }
+
+  private buildCategoryDisplay(): void {
+    const data = this.courseDataService.getCourseData();
+    this.displayCategories = [];
+
+    for (const req of data.requirements.req) {
+      const categoryDisplay: CategoryDisplay = {
+        reqName: req.name,
+        categories: []
+      };
+
+      for (const cat of req.categories) {
+        const courses = this.courseDataService.getCategoryCourses(cat.id);
+        categoryDisplay.categories.push({
+          id: cat.id,
+          name: cat.name,
+          courses,
+          selectedIds: []
+        });
+      }
+
+      this.displayCategories.push(categoryDisplay);
+    }
+
+    this.updateSelectedCourses();
+  }
+
+  private updateSelectedCourses(): void {
+    for (const req of this.displayCategories) {
+      for (const cat of req.categories) {
+        cat.selectedIds = cat.courses
+          .filter(c => this.selectedCourseIds.includes(c.id))
+          .map(c => c.id);
+      }
+    }
+  }
+}

--- a/src/app/planner/components/planner.component.html
+++ b/src/app/planner/components/planner.component.html
@@ -1,0 +1,221 @@
+<div class="planner-container" (click)="closeQuickAdd()">
+  <h1>Course Planner</h1>
+
+  <!-- Category Browser -->
+  <app-category-browser [selectedCourseIds]="selectedCourseIds"></app-category-browser>
+
+  <div class="controls-section">
+    <div class="controls">
+      <div class="control-group">
+        <label for="track-select">Specialization Track:</label>
+        <select id="track-select" [(ngModel)]="selectedTrackId" (change)="selectTrack(selectedTrackId)">
+          <option value="">None - General Requirements</option>
+          <option *ngFor="let track of availableTracks" [value]="track.id">
+            {{ track.name }}
+          </option>
+        </select>
+      </div>
+
+      <div class="control-group">
+        <label for="semester-select">Starting Semester:</label>
+        <select id="semester-select" [(ngModel)]="startSemester" (change)="onSemesterChange()">
+          <option *ngFor="let opt of getSemesterOptions()" [value]="opt.code">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+
+      <div class="control-group">
+        <label for="year-select">Year:</label>
+        <select id="year-select" [(ngModel)]="startYear" (change)="onYearChange()">
+          <option *ngFor="let year of getYearOptions()" [value]="year">
+            {{ year }}
+          </option>
+        </select>
+      </div>
+
+      <div class="control-group">
+        <label for="course-select">Add Course:</label>
+        <select id="course-select" [(ngModel)]="selectedCourse">
+          <option [ngValue]="null">Select a course...</option>
+          <option *ngFor="let course of getAvailableCourses()" [ngValue]="course">
+            {{ getCourseLabel(course) }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <div class="calculation-summary" *ngIf="calculation">
+    <div class="summary-item">
+      <h3>Total Credits</h3>
+      <p class="total-credits" [ngClass]="calculation.color">{{ calculation.total }}/32</p>
+    </div>
+
+    <div class="requirement-item" (click)="toggleBreadthDetails()">
+      <div class="requirement-header">
+        <h4>Breadth Category Requirements</h4>
+        <span class="expand-arrow">{{ breadthDetailsExpanded ? '▼' : '▶' }}</span>
+      </div>
+      <p class="credits" [ngClass]="calculation.breadthComplete === 4 ? 'color-ok' : 'color-notok'">
+        {{ calculation.breadthComplete }}/{{ calculation.breadthNeeded }} Categories
+      </p>
+      <div class="requirement-details" *ngIf="breadthDetailsExpanded">
+        <ul class="course-breakdown">
+          <li *ngFor="let courseId of calculation.breadthCourses">
+            {{ getCourseName(courseId) }}
+          </li>
+          <li *ngIf="calculation.breadthCourses.length === 0" class="no-courses">No courses yet</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="requirement-item" (click)="toggleAdvancedDetails()">
+      <div class="requirement-header">
+        <h4>Advanced Coursework</h4>
+        <span class="expand-arrow">{{ advancedDetailsExpanded ? '▼' : '▶' }}</span>
+      </div>
+      <p class="credits" [ngClass]="calculation.advancedComplete === 3 ? 'color-ok' : 'color-notok'">
+        {{ calculation.advancedComplete }}/{{ calculation.advancedNeeded }} Courses
+      </p>
+      <div class="requirement-details" *ngIf="advancedDetailsExpanded">
+        <ul class="course-breakdown">
+          <li *ngFor="let courseId of calculation.advancedCourses">
+            {{ getCourseName(courseId) }}
+          </li>
+          <li *ngIf="calculation.advancedCourses.length === 0" class="no-courses">No courses yet</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="requirement-item" (click)="toggleElectivesDetails()">
+      <div class="requirement-header">
+        <h4>Electives</h4>
+        <span class="expand-arrow">{{ electivesDetailsExpanded ? '▼' : '▶' }}</span>
+      </div>
+      <p class="credits" [ngClass]="calculation.electivesComplete >= 1 ? 'color-ok' : 'color-notok'">
+        {{ calculation.electivesComplete }}/{{ calculation.electivesNeeded }} Course
+      </p>
+      <div class="requirement-details" *ngIf="electivesDetailsExpanded">
+        <ul class="course-breakdown">
+          <li *ngFor="let courseId of calculation.electivesCourses">
+            {{ getCourseName(courseId) }}
+          </li>
+          <li *ngIf="calculation.electivesCourses.length === 0" class="no-courses">No courses yet</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Track Requirements Section -->
+  <div class="track-requirements" *ngIf="currentTrack">
+    <div class="track-header">
+      <button class="collapse-toggle" (click)="toggleTrackRequirementsCollapse()">
+        {{ trackRequirementsCollapsed ? '▶' : '▼' }}
+      </button>
+      <h2>{{ currentTrack.name }} Track Requirements</h2>
+    </div>
+    <p class="track-description">{{ currentTrack.description }}</p>
+
+    <div class="track-content" *ngIf="!trackRequirementsCollapsed">
+      <!-- Data Science Track Special Display -->
+      <div *ngIf="isDataScienceTrack" class="data-science-requirements">
+        <h3>Breadth Areas</h3>
+        <div class="breadth-areas-grid">
+          <div *ngFor="let area of getDataScienceBreadthAreas()" class="breadth-area">
+            <h4>{{ area.name }}</h4>
+            <p class="requirement">{{ area.required }} course required</p>
+            <ul class="course-list">
+              <li *ngFor="let courseId of area.courseIds"
+                  [ngClass]="{ 'course-selected': isCourseSelected(courseId) }">
+                {{ getCourseName(courseId) }}
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>Advanced Coursework</h3>
+        <ul class="course-list">
+          <li *ngFor="let courseId of getDataScienceAdvancedCourses()"
+              [ngClass]="{ 'course-selected': isCourseSelected(courseId) }">
+            {{ getCourseName(courseId) }}
+          </li>
+        </ul>
+
+        <h3>Recommended Electives</h3>
+        <ul class="course-list">
+          <li *ngFor="let courseId of getDataScienceElectives()"
+              [ngClass]="{ 'course-selected': isCourseSelected(courseId) }">
+            {{ getCourseName(courseId) }}
+          </li>
+        </ul>
+      </div>
+
+      <!-- Standard Track Display -->
+      <div *ngIf="!isDataScienceTrack" class="standard-track-requirements">
+        <div *ngFor="let req of currentTrack.requirements" class="track-requirement">
+          <h3>{{ req.name }}</h3>
+          <p class="requirement">{{ req.required }} courses required</p>
+          <p *ngIf="req.description" class="requirement-description">{{ req.description }}</p>
+          <ul class="course-list">
+            <li *ngFor="let courseId of req.courseIds"
+                [ngClass]="{ 'course-selected': isCourseSelected(courseId) }">
+              {{ getCourseName(courseId) }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="selection-boxes-container" (click)="closeQuickAdd()">
+    <div class="selection-box" *ngFor="let box of selectionBoxes; let boxIndex = index" (click)="closeQuickAdd()">
+      <div class="semester-header-wrapper">
+        <h3 class="semester-header">{{ box.name }}</h3>
+      </div>
+
+      <button class="quick-add-btn"
+              title="Add course to this semester"
+              (click)="toggleQuickAdd(boxIndex, $event)">+</button>
+      <div class="quick-add-dropdown" *ngIf="isQuickAddOpen(boxIndex)">
+        <input type="text" class="quick-add-search" placeholder="Search courses..." [(ngModel)]="quickAddSearch" (keydown)="onQuickAddKeydown($event)" (input)="quickAddSelectedIndex = 0" (click)="$event.stopPropagation()">
+        <div class="quick-add-courses">
+          <div class="quick-add-course"
+               *ngFor="let course of getFilteredAvailableCourses(); let i = index"
+               [ngClass]="{ 'quick-add-course-selected': i === quickAddSelectedIndex }"
+               (click)="addCourseFromBox(boxIndex, course); $event.stopPropagation()">
+            {{ course.code }} - {{ course.name }}
+          </div>
+        </div>
+      </div>
+
+      <div class="add-course-section">
+        <button class="add-btn" (click)="addCourse(boxIndex)" [disabled]="!selectedCourse">
+          Add Course
+        </button>
+      </div>
+
+      <div class="courses-list">
+        <div class="course-item" *ngFor="let course of box.courses">
+          <span class="course-code">{{ course.code }}</span>
+          <span class="course-name">{{ course.name }}</span>
+          <div class="course-controls">
+            <select *ngIf="hasCreditOptions(course)"
+                    class="credit-select"
+                    [(ngModel)]="course.creditHours"
+                    (change)="setCreditHours(course.id, course.creditHours || 4)">
+              <option *ngFor="let credits of course.creditOptions" [ngValue]="credits">
+                {{ credits }}h
+              </option>
+            </select>
+            <span *ngIf="!hasCreditOptions(course)" class="credit-display">{{ getCreditHours(course.id) }}h</span>
+          </div>
+          <button class="remove-btn" (click)="removeCourse(course.id, boxIndex)">✕</button>
+        </div>
+        <div *ngIf="box.courses.length === 0" class="empty-message">
+          No courses selected
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/planner/components/planner.component.scss
+++ b/src/app/planner/components/planner.component.scss
@@ -1,0 +1,594 @@
+.planner-container {
+  padding: 20px;
+  max-width: 1400px;
+  margin: 0 auto;
+
+  h1 {
+    text-align: center;
+    margin-bottom: 30px;
+    color: #333;
+  }
+}
+
+.controls-section {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 10px;
+  background: #f5f5f5;
+  padding: 20px;
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+
+.controls {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 300px;
+
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    label {
+      font-weight: 600;
+      font-size: 14px;
+      color: #333;
+    }
+
+    select {
+      padding: 8px 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 14px;
+      background: white;
+      cursor: pointer;
+      min-width: 150px;
+
+      &:focus {
+        outline: none;
+        border-color: #1976d2;
+        box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.1);
+      }
+    }
+  }
+}
+
+.calculation-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  background: transparent;
+  padding: 20px 0;
+  margin: 10px 0 20px 0;
+
+  .summary-item,
+  .requirement-item {
+    text-align: center;
+    padding: 12px;
+    background: #f5f5f5;
+    border-radius: 4px;
+    border: 1px solid #e0e0e0;
+
+    h3,
+    h4 {
+      margin: 0 0 8px 0;
+      font-size: 12px;
+      text-transform: uppercase;
+      color: #666;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+
+    p {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 700;
+
+      &.color-ok {
+        color: #4caf50;
+      }
+
+      &.color-notok {
+        color: #f44336;
+      }
+    }
+  }
+
+  .summary-item {
+    h3 {
+      font-size: 13px;
+    }
+
+    p {
+      font-size: 20px;
+      font-variant-numeric: proportional-nums;
+    }
+  }
+
+  .requirement-item {
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: #f0f0f0;
+    }
+
+    h4 {
+      font-size: 12px;
+    }
+
+    p {
+      font-size: 15px;
+    }
+
+    .requirement-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+
+      h4 {
+        margin: 0;
+      }
+
+      .expand-arrow {
+        font-size: 11px;
+        color: #666;
+        transition: transform 0.2s ease;
+      }
+    }
+
+    .requirement-details {
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid #e0e0e0;
+      animation: slideDown 0.2s ease-out;
+
+      .course-breakdown {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+
+        li {
+          padding: 6px 12px;
+          background: white;
+          border-left: 3px solid #1976d2;
+          margin: 4px 0;
+          font-size: 13px;
+          color: #333;
+          border-radius: 2px;
+
+          &.no-courses {
+            color: #999;
+            font-style: italic;
+            border-left-color: #ccc;
+          }
+        }
+      }
+    }
+  }
+}
+
+.selection-boxes-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.selection-box {
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: all 0.3s ease;
+  position: relative;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-color: #1976d2;
+  }
+
+  .semester-header-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .semester-header {
+    margin: 0 0 12px 0;
+    font-size: 16px;
+    font-weight: 700;
+    color: #1976d2;
+    border-bottom: 2px solid #e0e0e0;
+    padding-bottom: 8px;
+  }
+
+  .quick-add-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: #1976d2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 14px;
+    transition: all 0.2s ease;
+    z-index: 10;
+
+    &:hover {
+      background: #1565c0;
+      transform: scale(1.1);
+    }
+  }
+
+  .quick-add-dropdown {
+    position: absolute;
+    top: 48px;
+    right: 12px;
+    background: white;
+    border: 2px solid #1976d2;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    min-width: 280px;
+    max-width: 350px;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .quick-add-search {
+    width: 100%;
+    padding: 10px;
+    border: none;
+    border-bottom: 1px solid #e0e0e0;
+    font-size: 13px;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      background: #f5f5f5;
+    }
+  }
+
+  .quick-add-courses {
+    max-height: 250px;
+    overflow-y: auto;
+  }
+
+  .quick-add-course {
+    padding: 10px 12px;
+    cursor: pointer;
+    font-size: 13px;
+    color: #333;
+    transition: background 0.2s ease;
+    border-left: 3px solid transparent;
+
+    &:hover {
+      background: #e8f4fd;
+      border-left-color: #1976d2;
+    }
+
+    &.quick-add-course-selected {
+      background: #cce5ff;
+      border-left-color: #1976d2;
+      font-weight: 500;
+    }
+  }
+
+  .add-course-section {
+    margin-bottom: 12px;
+
+    .add-btn {
+      width: 100%;
+      padding: 8px 12px;
+      background: #1976d2;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background 0.3s;
+
+      &:hover:not(:disabled) {
+        background: #1565c0;
+      }
+
+      &:disabled {
+        background: #ccc;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .courses-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 100px;
+
+    .empty-message {
+      text-align: center;
+      color: #999;
+      font-size: 12px;
+      padding: 20px 0;
+    }
+  }
+}
+
+.course-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  border-left: 3px solid #1976d2;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #e8f4fd;
+  }
+
+  .course-code {
+    font-weight: 700;
+    color: #1976d2;
+    min-width: 60px;
+    font-size: 12px;
+  }
+
+  .course-name {
+    flex: 1;
+    font-size: 13px;
+    color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .course-controls {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+
+    .credit-select {
+      padding: 4px 6px;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      font-size: 12px;
+      background: white;
+      cursor: pointer;
+      min-width: 50px;
+
+      &:focus {
+        outline: none;
+        border-color: #1976d2;
+        box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.1);
+      }
+    }
+
+    .credit-display {
+      font-size: 12px;
+      color: #666;
+      min-width: 30px;
+      text-align: center;
+    }
+  }
+
+  .remove-btn {
+    padding: 4px 8px;
+    background: #f44336;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 12px;
+    transition: background 0.2s;
+
+    &:hover {
+      background: #d32f2f;
+    }
+  }
+}
+
+.track-requirements {
+  background: #f9f9f9;
+  border: 2px solid #1976d2;
+  border-radius: 8px;
+  padding: 20px;
+  margin: 20px 0;
+
+  .track-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+
+    .collapse-toggle {
+      background: none;
+      border: none;
+      font-size: 16px;
+      cursor: pointer;
+      padding: 4px 8px;
+      color: #1976d2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      transition: transform 0.2s;
+
+      &:hover {
+        background: rgba(25, 118, 210, 0.1);
+        border-radius: 4px;
+      }
+    }
+
+    h2 {
+      color: #1976d2;
+      margin: 0;
+      font-size: 20px;
+    }
+  }
+
+  .track-description {
+    color: #666;
+    font-size: 14px;
+    margin: 0 0 20px 0;
+    font-style: italic;
+  }
+
+  .track-content {
+    animation: slideDown 0.2s ease-out;
+  }
+
+  h3 {
+    color: #333;
+    margin: 16px 0 12px 0;
+    font-size: 16px;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 8px;
+  }
+
+  h4 {
+    color: #1976d2;
+    margin: 0 0 8px 0;
+    font-size: 14px;
+  }
+
+  .requirement {
+    margin: 0 0 8px 0;
+    font-size: 12px;
+    color: #666;
+    font-weight: 600;
+  }
+
+  .requirement-description {
+    margin: 0 0 8px 0;
+    font-size: 13px;
+    color: #555;
+  }
+
+  .course-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px 0;
+
+    li {
+      padding: 6px 12px;
+      background: white;
+      border-left: 3px solid #1976d2;
+      margin: 4px 0;
+      font-size: 13px;
+      color: #333;
+      border-radius: 2px;
+      transition: all 0.2s ease;
+
+      &.course-selected {
+        background: #e8f5e9;
+        border-left-color: #4caf50;
+        color: #2e7d32;
+        font-weight: 600;
+      }
+    }
+  }
+
+  .data-science-requirements {
+    .breadth-areas-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 16px;
+      margin: 12px 0 20px 0;
+    }
+
+    .breadth-area {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 12px;
+
+      h4 {
+        margin: 0 0 8px 0;
+        color: #1976d2;
+      }
+
+      .course-list li {
+        padding: 4px 8px;
+        font-size: 12px;
+        margin: 3px 0;
+      }
+    }
+  }
+
+  .standard-track-requirements {
+    .track-requirement {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 12px;
+      margin: 8px 0;
+
+      h3 {
+        margin: 0 0 8px 0;
+        border-bottom: 1px solid #e0e0e0;
+        padding-bottom: 6px;
+        font-size: 14px;
+      }
+
+      .course-list li {
+        padding: 4px 8px;
+        font-size: 12px;
+        margin: 3px 0;
+      }
+    }
+  }
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 1000px;
+  }
+}
+
+@media (max-width: 768px) {
+  .controls-section {
+    flex-direction: column;
+  }
+
+  .controls {
+    flex-direction: column;
+
+    .control-group select {
+      min-width: 100%;
+    }
+  }
+
+  .selection-boxes-container {
+    grid-template-columns: 1fr;
+  }
+
+  .track-requirements {
+    .data-science-requirements {
+      .breadth-areas-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+}

--- a/src/app/planner/components/planner.component.spec.ts
+++ b/src/app/planner/components/planner.component.spec.ts
@@ -1,0 +1,571 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { PlannerComponent } from './planner.component';
+import { CourseDataService, Course } from '../services/course-data.service';
+import { PlannerLogicService } from '../services/planner-logic.service';
+import { CategoryBrowserComponent } from './category-browser.component';
+
+describe('PlannerComponent', () => {
+  let component: PlannerComponent;
+  let fixture: ComponentFixture<PlannerComponent>;
+  let courseDataService: CourseDataService;
+  let plannerLogicService: PlannerLogicService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlannerComponent, FormsModule, CategoryBrowserComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PlannerComponent);
+    component = fixture.componentInstance;
+    courseDataService = TestBed.inject(CourseDataService);
+    plannerLogicService = TestBed.inject(PlannerLogicService);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with default values', () => {
+      expect(component.categories).toBeDefined();
+      expect(component.selectionBoxes).toBeDefined();
+      expect(component.allCourses).toBeDefined();
+      expect(component.availableTracks).toBeDefined();
+      expect(component.startSemester).toBeDefined();
+      expect(component.startYear).toBeDefined();
+    });
+
+    it('should load categories from planner logic service', () => {
+      expect(component.categories.length).toBeGreaterThan(0);
+    });
+
+    it('should load all courses from course data service', () => {
+      expect(component.allCourses.length).toBeGreaterThan(0);
+    });
+
+    it('should load available tracks', () => {
+      expect(Array.isArray(component.availableTracks)).toBe(true);
+    });
+
+    it('should set current semester on initialization', () => {
+      expect(['spring', 'summer', 'fall']).toContain(component.startSemester);
+    });
+
+    it('should generate selection boxes on init', () => {
+      expect(component.selectionBoxes.length).toBe(component.totalBoxes);
+    });
+
+    it('should have calculation result after init', () => {
+      expect(component.calculation).toBeDefined();
+    });
+  });
+
+  describe('generateSelectionBoxes', () => {
+    it('should generate correct number of boxes', () => {
+      component.totalBoxes = 9;
+      component.generateSelectionBoxes();
+      expect(component.selectionBoxes.length).toBe(9);
+    });
+
+    it('should update calculation after generating boxes', () => {
+      const initialCalc = component.calculation;
+      component.generateSelectionBoxes();
+      expect(component.calculation).toBeDefined();
+    });
+  });
+
+  describe('onSemesterChange', () => {
+    it('should update selection box labels when semester changes', () => {
+      component.startSemester = 'fall';
+      component.onSemesterChange();
+      expect(component.selectionBoxes[0].semester).toBe('fall');
+    });
+
+    it('should preserve existing courses when changing semester', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        component.selectionBoxes[0].courses.push(courses[0]);
+        const initialCourseCount = component.selectionBoxes[0].courses.length;
+        component.startSemester = 'summer';
+        component.onSemesterChange();
+        expect(component.selectionBoxes[0].courses.length).toBe(initialCourseCount);
+      }
+    });
+  });
+
+  describe('onYearChange', () => {
+    it('should update selection box labels when year changes', () => {
+      component.startYear = 2025;
+      component.onYearChange();
+      expect(component.selectionBoxes[0].year).toBe(2025);
+    });
+
+    it('should preserve existing courses when changing year', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        component.selectionBoxes[0].courses.push(courses[0]);
+        const initialCourseCount = component.selectionBoxes[0].courses.length;
+        component.startYear = 2026;
+        component.onYearChange();
+        expect(component.selectionBoxes[0].courses.length).toBe(initialCourseCount);
+      }
+    });
+  });
+
+  describe('addCourse', () => {
+    it('should not add course if none selected', async () => {
+      component.selectedCourse = null;
+      const initialLength = component.selectionBoxes[0].courses.length;
+      await component.addCourse(0);
+      expect(component.selectionBoxes[0].courses.length).toBe(initialLength);
+    });
+
+    it('should add course to selection box', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const springCourse = courses.find(c => c.semester.includes('spring'));
+      if (springCourse) {
+        component.selectionBoxes[0].semester = 'spring';
+        component.selectedCourse = springCourse;
+        
+        spyOn(window, 'confirm').and.returnValue(true);
+        await component.addCourse(0);
+        
+        expect(component.selectionBoxes[0].courses).toContain(springCourse);
+      }
+    });
+
+    it('should clear selected course after adding', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const springCourse = courses.find(c => c.semester.includes('spring'));
+      if (springCourse) {
+        component.selectionBoxes[0].semester = 'spring';
+        component.selectedCourse = springCourse;
+        
+        spyOn(window, 'confirm').and.returnValue(true);
+        await component.addCourse(0);
+        
+        expect(component.selectedCourse).toBeNull();
+      }
+    });
+
+    it('should update calculation after adding course', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const springCourse = courses.find(c => c.semester.includes('spring'));
+      if (springCourse) {
+        component.selectionBoxes[0].semester = 'spring';
+        component.selectedCourse = springCourse;
+        
+        spyOn(window, 'confirm').and.returnValue(true);
+        const initialTotal = component.calculation?.total || 0;
+        await component.addCourse(0);
+        
+        expect(component.calculation).toBeDefined();
+      }
+    });
+  });
+
+  describe('removeCourse', () => {
+    it('should remove course from selection box', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const course = courses[0];
+        component.selectionBoxes[0].courses.push(course);
+        plannerLogicService.addCourse(course.id);
+        
+        component.removeCourse(course.id, 0);
+        
+        expect(component.selectionBoxes[0].courses).not.toContain(course);
+      }
+    });
+
+    it('should update calculation after removing course', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const course = courses[0];
+        component.selectionBoxes[0].courses.push(course);
+        plannerLogicService.addCourse(course.id);
+        
+        component.removeCourse(course.id, 0);
+        
+        expect(component.calculation).toBeDefined();
+      }
+    });
+
+    it('should handle removing non-existent course gracefully', () => {
+      const initialLength = component.selectionBoxes[0].courses.length;
+      component.removeCourse('non-existent-xyz', 0);
+      expect(component.selectionBoxes[0].courses.length).toBe(initialLength);
+    });
+  });
+
+  describe('getAvailableCourses', () => {
+    it('should return courses not already selected', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        plannerLogicService.addCourse(courses[0].id);
+        component.selectedCourseIds = [courses[0].id];
+        
+        const available = component.getAvailableCourses();
+        expect(available.find(c => c.id === courses[0].id)).toBeUndefined();
+      }
+    });
+
+    it('should sort courses by course number', () => {
+      const available = component.getAvailableCourses();
+      for (let i = 1; i < available.length; i++) {
+        const prevNum = parseInt(available[i - 1].code.match(/\d+/)?.[0] || '0', 10);
+        const currNum = parseInt(available[i].code.match(/\d+/)?.[0] || '0', 10);
+        expect(currNum).toBeGreaterThanOrEqual(prevNum);
+      }
+    });
+  });
+
+  describe('getSemesterOptions', () => {
+    it('should return three semester options', () => {
+      const options = component.getSemesterOptions();
+      expect(options.length).toBe(3);
+    });
+
+    it('should include spring, summer, and fall', () => {
+      const options = component.getSemesterOptions();
+      const codes = options.map(o => o.code);
+      expect(codes).toContain('spring');
+      expect(codes).toContain('summer');
+      expect(codes).toContain('fall');
+    });
+  });
+
+  describe('getYearOptions', () => {
+    it('should return year options', () => {
+      const options = component.getYearOptions();
+      expect(options.length).toBeGreaterThan(0);
+    });
+
+    it('should include current year', () => {
+      const options = component.getYearOptions();
+      expect(options).toContain(component.startYear);
+    });
+
+    it('should include past and future years', () => {
+      const options = component.getYearOptions();
+      expect(options.length).toBeGreaterThan(3);
+    });
+  });
+
+  describe('getCourseLabel', () => {
+    it('should return formatted course label', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const label = component.getCourseLabel(courses[0]);
+        expect(label).toContain(courses[0].code);
+        expect(label).toContain(courses[0].name);
+        expect(label).toContain(' - ');
+      }
+    });
+  });
+
+  describe('hasCreditOptions', () => {
+    it('should return true for courses with multiple credit options', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithOptions = courses.find(c => c.creditOptions && c.creditOptions.length > 1);
+      if (courseWithOptions) {
+        expect(component.hasCreditOptions(courseWithOptions)).toBe(true);
+      }
+    });
+
+    it('should return false for courses without credit options', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithoutOptions = courses.find(c => !c.creditOptions || c.creditOptions.length <= 1);
+      if (courseWithoutOptions) {
+        expect(component.hasCreditOptions(courseWithoutOptions)).toBe(false);
+      }
+    });
+  });
+
+  describe('getCreditHours and setCreditHours', () => {
+    it('should get credit hours from planner logic service', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const credits = component.getCreditHours(courses[0].id);
+        expect(typeof credits).toBe('number');
+        expect(credits).toBeGreaterThan(0);
+      }
+    });
+
+    it('should set credit hours and update calculation', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        component.setCreditHours(courseId, 3);
+        expect(plannerLogicService.getCreditHours(courseId)).toBe(3);
+      }
+    });
+  });
+
+  describe('Track Selection', () => {
+    it('should select track', () => {
+      const tracks = component.availableTracks;
+      if (tracks.length > 0) {
+        component.selectTrack(tracks[0].id);
+        expect(component.selectedTrackId).toBe(tracks[0].id);
+        expect(component.currentTrack).toBeDefined();
+      }
+    });
+
+    it('should clear track selection', () => {
+      const tracks = component.availableTracks;
+      if (tracks.length > 0) {
+        component.selectTrack(tracks[0].id);
+        component.clearTrackSelection();
+        expect(component.selectedTrackId).toBe('');
+        expect(component.currentTrack).toBeNull();
+      }
+    });
+
+    it('should identify data science track', () => {
+      component.selectTrack('ds');
+      expect(component.isDataScienceTrack).toBe(true);
+    });
+  });
+
+  describe('getTrackName', () => {
+    it('should return track name for valid id', () => {
+      const tracks = component.availableTracks;
+      if (tracks.length > 0) {
+        const name = component.getTrackName(tracks[0].id);
+        expect(name).toBe(tracks[0].name);
+      }
+    });
+
+    it('should return empty string for invalid id', () => {
+      const name = component.getTrackName('invalid-track-xyz');
+      expect(name).toBe('');
+    });
+  });
+
+  describe('getCourseName and getCourseCode', () => {
+    it('should return course name for valid id', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const name = component.getCourseName(courses[0].id);
+        expect(name).toContain(courses[0].code);
+        expect(name).toContain(courses[0].name);
+      }
+    });
+
+    it('should return course code for valid id', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const code = component.getCourseCode(courses[0].id);
+        expect(code).toBe(courses[0].code);
+      }
+    });
+
+    it('should return course id when course not found', () => {
+      const name = component.getCourseName('invalid-xyz');
+      expect(name).toBe('invalid-xyz');
+      
+      const code = component.getCourseCode('invalid-xyz');
+      expect(code).toBe('invalid-xyz');
+    });
+  });
+
+  describe('toggleTrackRequirementsCollapse', () => {
+    it('should toggle collapse state', () => {
+      const initialState = component.trackRequirementsCollapsed;
+      component.toggleTrackRequirementsCollapse();
+      expect(component.trackRequirementsCollapsed).toBe(!initialState);
+    });
+  });
+
+  describe('isCourseSelected', () => {
+    it('should return true for selected course', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        component.selectedCourseIds = [courses[0].id];
+        expect(component.isCourseSelected(courses[0].id)).toBe(true);
+      }
+    });
+
+    it('should return false for non-selected course', () => {
+      component.selectedCourseIds = [];
+      expect(component.isCourseSelected('some-course-id')).toBe(false);
+    });
+  });
+
+  describe('Quick Add functionality', () => {
+    it('should toggle quick add dropdown', () => {
+      const event = new Event('click');
+      component.toggleQuickAdd(0, event);
+      expect(component.quickAddOpenBox).toBe(0);
+      
+      component.toggleQuickAdd(0, event);
+      expect(component.quickAddOpenBox).toBeNull();
+    });
+
+    it('should close quick add', () => {
+      component.quickAddOpenBox = 0;
+      component.closeQuickAdd();
+      expect(component.quickAddOpenBox).toBeNull();
+    });
+
+    it('should check if quick add is open', () => {
+      component.quickAddOpenBox = 0;
+      expect(component.isQuickAddOpen(0)).toBe(true);
+      expect(component.isQuickAddOpen(1)).toBe(false);
+    });
+
+    it('should filter available courses', () => {
+      component.quickAddSearch = '';
+      const allAvailable = component.getFilteredAvailableCourses();
+      
+      component.quickAddSearch = '410';
+      const filtered = component.getFilteredAvailableCourses();
+      
+      expect(filtered.length).toBeLessThanOrEqual(allAvailable.length);
+    });
+
+    it('should handle quick add keyboard navigation', () => {
+      component.quickAddOpenBox = 0;
+      component.quickAddSelectedIndex = 0;
+      
+      const downEvent = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+      component.onQuickAddKeydown(downEvent);
+      expect(component.quickAddSelectedIndex).toBe(1);
+      
+      const upEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+      component.onQuickAddKeydown(upEvent);
+      expect(component.quickAddSelectedIndex).toBe(0);
+      
+      const escEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+      component.onQuickAddKeydown(escEvent);
+      expect(component.quickAddOpenBox).toBeNull();
+    });
+  });
+
+  describe('Detail toggles', () => {
+    it('should toggle breadth details', () => {
+      const initial = component.breadthDetailsExpanded;
+      component.toggleBreadthDetails();
+      expect(component.breadthDetailsExpanded).toBe(!initial);
+    });
+
+    it('should toggle advanced details', () => {
+      const initial = component.advancedDetailsExpanded;
+      component.toggleAdvancedDetails();
+      expect(component.advancedDetailsExpanded).toBe(!initial);
+    });
+
+    it('should toggle electives details', () => {
+      const initial = component.electivesDetailsExpanded;
+      component.toggleElectivesDetails();
+      expect(component.electivesDetailsExpanded).toBe(!initial);
+    });
+  });
+
+  describe('Data Science Track methods', () => {
+    beforeEach(() => {
+      component.selectTrack('ds');
+    });
+
+    it('should get breadth areas for data science track', () => {
+      const areas = component.getDataScienceBreadthAreas();
+      expect(Array.isArray(areas)).toBe(true);
+      if (component.isDataScienceTrack) {
+        expect(areas.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should get advanced courses for data science track', () => {
+      const courses = component.getDataScienceAdvancedCourses();
+      expect(Array.isArray(courses)).toBe(true);
+      if (component.isDataScienceTrack) {
+        expect(courses.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should get electives for data science track', () => {
+      const electives = component.getDataScienceElectives();
+      expect(Array.isArray(electives)).toBe(true);
+    });
+
+    it('should return empty array when not data science track', () => {
+      component.clearTrackSelection();
+      expect(component.getDataScienceBreadthAreas()).toEqual([]);
+      expect(component.getDataScienceAdvancedCourses()).toEqual([]);
+      expect(component.getDataScienceElectives()).toEqual([]);
+    });
+  });
+
+  describe('Edge cases and confirm dialogs', () => {
+    it('should handle confirm rejection when adding course to wrong semester', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const fallOnlyCourse = courses.find((c: Course) => 
+        c.semester.includes('fall') && !c.semester.includes('spring')
+      );
+      
+      if (fallOnlyCourse) {
+        component.selectionBoxes[0].semester = 'spring';
+        component.selectedCourse = fallOnlyCourse;
+        
+        spyOn(window, 'confirm').and.returnValue(false);
+        const initialLength = component.selectionBoxes[0].courses.length;
+        
+        await component.addCourse(0);
+        
+        expect(component.selectionBoxes[0].courses.length).toBe(initialLength);
+      }
+    });
+
+    it('should handle confirm rejection when prerequisite not met', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithPrereq = courses.find((c: Course) => c.prerequisite && c.prerequisite.minimum > 0);
+      
+      if (courseWithPrereq) {
+        component.selectedCourse = courseWithPrereq;
+        
+        spyOn(window, 'confirm').and.returnValue(false);
+        const initialLength = component.selectionBoxes[0].courses.length;
+        
+        await component.addCourse(0);
+        
+        expect(component.selectionBoxes[0].courses.length).toBe(initialLength);
+      }
+    });
+
+    it('should handle addCourseFromBox with wrong semester and user confirmation', async () => {
+      const courses = courseDataService.getCourseData().courses;
+      const fallOnlyCourse = courses.find((c: Course) => 
+        c.semester.includes('fall') && !c.semester.includes('spring')
+      );
+      
+      if (fallOnlyCourse) {
+        component.selectionBoxes[0].semester = 'spring';
+        
+        spyOn(window, 'confirm').and.returnValue(true);
+        await component.addCourseFromBox(0, fallOnlyCourse);
+        
+        expect(component.selectionBoxes[0].courses).toContain(fallOnlyCourse);
+      }
+    });
+
+    it('should handle Enter key in quick add with valid selection', () => {
+      component.quickAddOpenBox = 0;
+      component.quickAddSelectedIndex = 0;
+      component.quickAddSearch = '';
+      
+      const filteredCourses = component.getFilteredAvailableCourses();
+      if (filteredCourses.length > 0) {
+        spyOn(component, 'addCourseFromBox');
+        
+        const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+        component.onQuickAddKeydown(enterEvent);
+        
+        expect(component.addCourseFromBox).toHaveBeenCalledWith(0, filteredCourses[0]);
+      }
+    });
+  });
+});

--- a/src/app/planner/components/planner.component.ts
+++ b/src/app/planner/components/planner.component.ts
@@ -1,0 +1,381 @@
+/**
+ * Based on UIUC MCS Course Planner (https://github.com/uiucmcs/courseplanner)
+ * Copyright (c) 2021 UIUC MCS Community
+ * Licensed under the MIT License
+ */
+
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { CourseDataService, Course, Track, DataScienceTrack } from '../services/course-data.service';
+import { PlannerLogicService, SelectionBox, CalculationResult, Category } from '../services/planner-logic.service';
+import { CategoryBrowserComponent } from './category-browser.component';
+import { TrackId, Semester, TOTAL_BOXES, DEFAULT_CREDITS } from '../constants/enums';
+
+@Component({
+  selector: 'app-planner',
+  templateUrl: './planner.component.html',
+  styleUrls: ['./planner.component.scss'],
+  standalone: true,
+  imports: [CommonModule, FormsModule, CategoryBrowserComponent]
+})
+export class PlannerComponent implements OnInit {
+  categories: Category[] = [];
+  selectionBoxes: SelectionBox[] = [];
+  calculation: CalculationResult | null = null;
+  startSemester: string = '';
+  startYear: number = new Date().getFullYear();
+  selectedCourse: Course | null = null;
+  allCourses: Course[] = [];
+  totalBoxes: number = TOTAL_BOXES;
+  perCredit: number = DEFAULT_CREDITS;
+  prerequisiteWarning: { show: boolean; message: string } = { show: false, message: '' };
+  selectedCourseIds: string[] = [];
+
+  // Track-related properties
+  availableTracks: Track[] = [];
+  selectedTrackId: string = '';
+  currentTrack: Track | DataScienceTrack | null = null;
+  isDataScienceTrack: boolean = false;
+  trackRequirementsCollapsed: boolean = true;
+  quickAddSearch: string = '';
+  quickAddOpenBox: number | null = null;
+  quickAddSelectedIndex: number = -1;
+  breadthDetailsExpanded: boolean = false;
+  advancedDetailsExpanded: boolean = false;
+  electivesDetailsExpanded: boolean = false;
+
+  constructor(
+    private courseDataService: CourseDataService,
+    private plannerLogicService: PlannerLogicService
+  ) {
+    this.categories = this.plannerLogicService.getCategories();
+    this.allCourses = this.courseDataService.getCourseData().courses;
+    this.startSemester = this.plannerLogicService.getCurrentSemester();
+    this.availableTracks = this.courseDataService.getTracks();
+  }
+
+  ngOnInit(): void {
+    this.generateSelectionBoxes();
+    this.updateCalculation();
+  }
+
+  generateSelectionBoxes(): void {
+    this.selectionBoxes = this.plannerLogicService.getSelectionBoxes(
+      this.startSemester,
+      this.startYear,
+      this.totalBoxes
+    );
+    this.updateCalculation();
+  }
+
+  private updateSelectionBoxLabels(): void {
+    // Preserve existing courses but update semester labels and years
+    const newBoxes = this.plannerLogicService.getSelectionBoxes(
+      this.startSemester,
+      this.startYear,
+      this.totalBoxes
+    );
+
+    // Update each box with new name/semester/year but keep existing courses
+    for (let i = 0; i < this.selectionBoxes.length && i < newBoxes.length; i++) {
+      this.selectionBoxes[i].name = newBoxes[i].name;
+      this.selectionBoxes[i].semester = newBoxes[i].semester;
+      this.selectionBoxes[i].year = newBoxes[i].year;
+    }
+
+    this.updateCalculation();
+  }
+
+  onSemesterChange(): void {
+    this.updateSelectionBoxLabels();
+  }
+
+  onYearChange(): void {
+    this.updateSelectionBoxLabels();
+  }
+
+  async addCourse(boxIndex: number): Promise<void> {
+    if (!this.selectedCourse) return;
+
+    const semester = this.selectionBoxes[boxIndex].semester;
+    const course = this.selectedCourse;
+
+    // Check if semester availability
+    if (!course.semester.includes(semester)) {
+      const semText = semester.charAt(0).toUpperCase() + semester.slice(1);
+      const proceed = confirm(
+        `${course.code} ${course.name} is usually not offered in the ${semText} semester. ` +
+        `Generally offered in ${course.semester.join(', ')} semester(s).\n\nAdd to ${semText} anyway?`
+      );
+      if (!proceed) return;
+    }
+
+    // Check prerequisites
+    const prereqCheck = this.plannerLogicService.checkPrerequisite(course.id);
+    if (!prereqCheck.valid) {
+      const proceed = confirm(
+        `${prereqCheck.message}\n\nAdd to ${this.selectionBoxes[boxIndex].name} anyway?`
+      );
+      if (!proceed) return;
+    }
+
+    this.plannerLogicService.addCourse(course.id);
+    this.selectionBoxes[boxIndex].courses.push(course);
+    this.selectedCourse = null;
+    this.updateSelectedCourseIds();
+    this.updateCalculation();
+  }
+
+  removeCourse(courseId: string, boxIndex: number): void {
+    const course = this.selectionBoxes[boxIndex].courses.find(c => c.id === courseId);
+    if (course) {
+      this.plannerLogicService.removeCourse(courseId);
+      const index = this.selectionBoxes[boxIndex].courses.indexOf(course);
+      if (index > -1) {
+        this.selectionBoxes[boxIndex].courses.splice(index, 1);
+      }
+      this.updateSelectedCourseIds();
+      this.updateCalculation();
+    }
+  }
+
+  private updateSelectedCourseIds(): void {
+    this.selectedCourseIds = this.plannerLogicService.getSelectedCourses();
+  }
+
+  updateCalculation(): void {
+    this.calculation = this.plannerLogicService.calculate();
+  }
+
+  getAvailableCourses(): Course[] {
+    const selected = this.plannerLogicService.getSelectedCourses();
+    return this.allCourses
+      .filter(c => !selected.includes(c.id))
+      .sort((a, b) => {
+        // Extract course numbers (e.g., "410" from "CS 410")
+        const aNum = parseInt(a.code.match(/\d+/)?.[0] || '0', 10);
+        const bNum = parseInt(b.code.match(/\d+/)?.[0] || '0', 10);
+        return aNum - bNum;
+      });
+  }
+
+  getSemesterOptions(): { label: string; code: string }[] {
+    return [
+      { label: 'Spring', code: Semester.SPRING },
+      { label: 'Summer', code: Semester.SUMMER },
+      { label: 'Fall', code: Semester.FALL }
+    ];
+  }
+
+  getYearOptions(): number[] {
+    const years: number[] = [];
+    for (let i = this.startYear - 5; i <= this.startYear + 1; i++) {
+      years.push(i);
+    }
+    return years;
+  }
+
+  getCourseLabel(course: Course): string {
+    return `${course.code} - ${course.name}`;
+  }
+
+  hasCreditOptions(course: Course): boolean {
+    return !!(course.creditOptions && course.creditOptions.length > 1);
+  }
+
+  getCreditHours(courseId: string): number {
+    return this.plannerLogicService.getCreditHours(courseId);
+  }
+
+  setCreditHours(courseId: string, credits: number): void {
+    this.plannerLogicService.setCreditHours(courseId, credits);
+    this.updateCalculation();
+  }
+
+  selectTrack(trackId: string): void {
+    this.selectedTrackId = trackId;
+
+    if (trackId === TrackId.DATA_SCIENCE) {
+      this.currentTrack = this.courseDataService.getDataScienceTrack();
+      this.isDataScienceTrack = true;
+    } else if (trackId) {
+      const track = this.courseDataService.getTrack(trackId);
+      this.currentTrack = track || null;
+      this.isDataScienceTrack = false;
+    } else {
+      this.currentTrack = null;
+      this.isDataScienceTrack = false;
+    }
+  }
+
+  clearTrackSelection(): void {
+    this.selectedTrackId = '';
+    this.currentTrack = null;
+    this.isDataScienceTrack = false;
+  }
+
+  getTrackName(trackId: string): string {
+    const track = this.availableTracks.find(t => t.id === trackId);
+    return track?.name || '';
+  }
+
+  getCourseName(courseId: string): string {
+    const course = this.allCourses.find(c => c.id === courseId);
+    return course ? `${course.code} - ${course.name}` : courseId;
+  }
+
+  getCourseCode(courseId: string): string {
+    const course = this.allCourses.find(c => c.id === courseId);
+    return course?.code || courseId;
+  }
+
+  getDataScienceBreadthAreas(): any[] {
+    if (this.isDataScienceTrack && this.currentTrack) {
+      return (this.currentTrack as any).breadthAreas || [];
+    }
+    return [];
+  }
+
+  getDataScienceAdvancedCourses(): string[] {
+    if (this.isDataScienceTrack && this.currentTrack) {
+      return (this.currentTrack as any).advancedCourseIds || [];
+    }
+    return [];
+  }
+
+  getDataScienceElectives(): string[] {
+    if (this.isDataScienceTrack && this.currentTrack) {
+      return (this.currentTrack as any).recommendedElectiveIds || [];
+    }
+    return [];
+  }
+
+  toggleTrackRequirementsCollapse(): void {
+    this.trackRequirementsCollapsed = !this.trackRequirementsCollapsed;
+  }
+
+  isCourseSelected(courseId: string): boolean {
+    return this.selectedCourseIds.includes(courseId);
+  }
+
+  async addCourseFromBox(boxIndex: number, course: Course): Promise<void> {
+    const semester = this.selectionBoxes[boxIndex].semester;
+
+    // Check if semester availability
+    if (!course.semester.includes(semester)) {
+      const semText = semester.charAt(0).toUpperCase() + semester.slice(1);
+      const proceed = confirm(
+        `${course.code} ${course.name} is usually not offered in the ${semText} semester. ` +
+        `Generally offered in ${course.semester.join(', ')} semester(s).\n\nAdd to ${semText} anyway?`
+      );
+      if (!proceed) return;
+    }
+
+    // Check prerequisites
+    const prereqCheck = this.plannerLogicService.checkPrerequisite(course.id);
+    if (!prereqCheck.valid) {
+      const proceed = confirm(
+        `${prereqCheck.message}\n\nAdd to ${this.selectionBoxes[boxIndex].name} anyway?`
+      );
+      if (!proceed) return;
+    }
+
+    this.plannerLogicService.addCourse(course.id);
+    this.selectionBoxes[boxIndex].courses.push(course);
+    this.quickAddSearch = ''; // Clear search after adding
+    this.updateSelectedCourseIds();
+    this.updateCalculation();
+
+    // Refocus the search input for quick iteration
+    setTimeout(() => {
+      const searchInput = document.querySelector(
+        `.selection-box:nth-child(${boxIndex + 1}) .quick-add-search`
+      ) as HTMLInputElement;
+      if (searchInput) {
+        searchInput.focus();
+      }
+    }, 0);
+  }
+
+  getFilteredAvailableCourses(): Course[] {
+    const searchTerm = this.quickAddSearch.toLowerCase();
+    const available = this.getAvailableCourses();
+
+    if (!searchTerm) {
+      return available;
+    }
+
+    return available.filter(course =>
+      course.code.toLowerCase().includes(searchTerm) ||
+      course.name.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  toggleQuickAdd(boxIndex: number, event: Event): void {
+    event.stopPropagation();
+    if (this.quickAddOpenBox === boxIndex) {
+      this.quickAddOpenBox = null;
+      this.quickAddSelectedIndex = -1;
+    } else {
+      this.quickAddOpenBox = boxIndex;
+      this.quickAddSelectedIndex = 0; // Start with first course selected
+      // Focus the search input after the dropdown is rendered
+      setTimeout(() => {
+        const searchInput = document.querySelector(
+          `.selection-box:nth-child(${boxIndex + 1}) .quick-add-search`
+        ) as HTMLInputElement;
+        if (searchInput) {
+          searchInput.focus();
+        }
+      }, 0);
+    }
+  }
+
+  closeQuickAdd(): void {
+    this.quickAddOpenBox = null;
+  }
+
+  isQuickAddOpen(boxIndex: number): boolean {
+    return this.quickAddOpenBox === boxIndex;
+  }
+
+  onQuickAddKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.closeQuickAdd();
+      this.quickAddSelectedIndex = -1;
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const filteredCourses = this.getFilteredAvailableCourses();
+      if (this.quickAddSelectedIndex < filteredCourses.length - 1) {
+        this.quickAddSelectedIndex++;
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (this.quickAddSelectedIndex > 0) {
+        this.quickAddSelectedIndex--;
+      }
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const filteredCourses = this.getFilteredAvailableCourses();
+      if (this.quickAddSelectedIndex >= 0 && this.quickAddSelectedIndex < filteredCourses.length) {
+        if (this.quickAddOpenBox !== null) {
+          this.addCourseFromBox(this.quickAddOpenBox, filteredCourses[this.quickAddSelectedIndex]);
+          this.quickAddSelectedIndex = -1;
+        }
+      }
+    }
+  }
+
+  toggleBreadthDetails(): void {
+    this.breadthDetailsExpanded = !this.breadthDetailsExpanded;
+  }
+
+  toggleAdvancedDetails(): void {
+    this.advancedDetailsExpanded = !this.advancedDetailsExpanded;
+  }
+
+  toggleElectivesDetails(): void {
+    this.electivesDetailsExpanded = !this.electivesDetailsExpanded;
+  }
+}

--- a/src/app/planner/constants/course-data.constants.ts
+++ b/src/app/planner/constants/course-data.constants.ts
@@ -1,0 +1,242 @@
+/**
+ * Course data constants
+ * This file contains all course information, requirements, and track definitions
+ * 
+ * Based on UIUC MCS Course Planner (https://github.com/uiucmcs/courseplanner)
+ * Copyright (c) 2021 UIUC MCS Community
+ * Licensed under the MIT License
+ */
+
+import { CourseId, CourseCode, CategoryId, TrackId, Semester } from './enums';
+import { CourseData } from '../services/course-data.service';
+
+export const COURSE_DATA: CourseData = {
+  requirements: {
+    total: {
+      required: 8,
+      minimum_credit: 32,
+    },
+    req: [
+      {
+        name: "Breadth Requirements",
+        required: 4,
+        minimum_credit: 12,
+        categories: [
+          { id: CategoryId.ARCHITECTURE, name: "Architecture, Compilers, Parallel Computing" },
+          { id: CategoryId.ARTIFICIAL_INTELLIGENCE, name: "Artificial Intelligence" },
+          { id: CategoryId.DATABASE_AND_INFORMATION_SYSTEMS, name: "Database & Information Systems" },
+          { id: CategoryId.INTERACTIVE_COMPUTING, name: "Interactive Computing" },
+          { id: CategoryId.PROGRAMMING_LANGUAGES, name: "Programming Languages, Formal Methods, Software Engineering" },
+          { id: CategoryId.SCIENTIFIC_COMPUTING, name: "Scientific Computing" },
+          { id: CategoryId.SECURITY_AND_PRIVACY, name: "Security & Privacy" },
+          { id: CategoryId.SYSTEMS_AND_NETWORKING, name: "Systems & Networking" },
+          { id: CategoryId.THEORY_AND_ALGORITHMS, name: "Theory & Algorithms" },
+        ],
+      },
+      {
+        name: "Advanced Coursework",
+        required: 3,
+        minimum_credit: 12,
+        categories: [
+          { id: CategoryId.ADVANCED_COURSEWORK, name: "Advanced Coursework (CS 500-level)" },
+        ],
+      },
+      {
+        name: "Electives",
+        required: 1,
+        minimum_credit: 4,
+        categories: [
+          { id: CategoryId.ELECTIVES, name: "Electives (Graduate-level)" },
+        ],
+      },
+    ],
+  },
+  courses: [
+    // Architecture, Compilers, Parallel Computing - Online Available
+    { id: CourseId.PARALLEL_PROGRAMMING, code: CourseCode.CS_484, name: "Parallel Programming", semester: [Semester.SPRING], category: [CategoryId.ARCHITECTURE], creditOptions: [3, 4], creditHours: 4 },
+
+    // Artificial Intelligence - Online Available
+    { id: CourseId.ARTIFICIAL_INTELLIGENCE, code: CourseCode.CS_440, name: "Artificial Intelligence", semester: [Semester.SPRING], category: [CategoryId.ARTIFICIAL_INTELLIGENCE], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.APPLIED_MACHINE_LEARNING, code: CourseCode.CS_441, name: "Applied Machine Learning", semester: [Semester.FALL, Semester.SPRING], category: [CategoryId.ARTIFICIAL_INTELLIGENCE], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.COMPUTATIONAL_PHOTOGRAPHY, code: CourseCode.CS_445, name: "Computational Photography", semester: [Semester.SPRING], category: [CategoryId.ARTIFICIAL_INTELLIGENCE, CategoryId.INTERACTIVE_COMPUTING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.MACHINE_LEARNING, code: CourseCode.CS_446, name: "Machine Learning", semester: [Semester.FALL], category: [CategoryId.ARTIFICIAL_INTELLIGENCE], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.NATURAL_LANGUAGE_PROCESSING, code: CourseCode.CS_447, name: "Natural Language Processing", semester: [Semester.FALL], category: [CategoryId.ARTIFICIAL_INTELLIGENCE], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.DEEP_LEARNING_FOR_HEALTHCARE, code: CourseCode.CS_598, name: "Deep Learning for Healthcare", semester: [Semester.SPRING], category: [CategoryId.ARTIFICIAL_INTELLIGENCE, CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 0, courses: { mandatory: [], optional: [CourseId.APPLIED_MACHINE_LEARNING] } } },
+
+    // Database & Information Systems - Online Available
+    { id: CourseId.TEXT_INFORMATION_SYSTEMS, code: CourseCode.CS_410, name: "Text Information Systems", semester: [Semester.FALL], category: [CategoryId.DATABASE_AND_INFORMATION_SYSTEMS], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.DATABASE_SYSTEMS, code: CourseCode.CS_411, name: "Database Systems", semester: [Semester.SPRING], category: [CategoryId.DATABASE_AND_INFORMATION_SYSTEMS], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.INTRODUCTION_TO_DATA_MINING, code: CourseCode.CS_412, name: "Introduction to Data Mining", semester: [Semester.SPRING], category: [CategoryId.DATABASE_AND_INFORMATION_SYSTEMS], creditOptions: [3, 4], creditHours: 4 },
+
+    // Interactive Computing - Online Available
+    { id: CourseId.DATA_VISUALIZATION, code: CourseCode.CS_416, name: "Data Visualization", semester: [Semester.SUMMER], category: [CategoryId.INTERACTIVE_COMPUTING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.INTERACTIVE_COMPUTER_GRAPHICS, code: CourseCode.CS_418, name: "Interactive Computer Graphics", semester: [Semester.FALL, Semester.SPRING], category: [CategoryId.INTERACTIVE_COMPUTING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.SCIENTIFIC_VISUALIZATION, code: CourseCode.CS_519, name: "Scientific Visualization", semester: [Semester.SUMMER], category: [CategoryId.INTERACTIVE_COMPUTING, CategoryId.ADVANCED_COURSEWORK], creditHours: 4, prerequisite: { minimum: 0, courses: { mandatory: [], optional: [CourseId.INTERACTIVE_COMPUTER_GRAPHICS, CourseId.DATA_VISUALIZATION] } } },
+
+    // Programming Languages, Formal Methods, Software Engineering - Online Available
+    { id: CourseId.PROGRAMMING_LANGUAGES_AND_COMPILERS, code: CourseCode.CS_421, name: "Programming Languages and Compilers", semester: [Semester.SUMMER], category: [CategoryId.PROGRAMMING_LANGUAGES], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.SOFTWARE_ENGINEERING_I, code: CourseCode.CS_427, name: "Software Engineering I", semester: [Semester.FALL], category: [CategoryId.PROGRAMMING_LANGUAGES], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.FORMAL_MODELS_OF_COMPUTATION, code: CourseCode.CS_475, name: "Formal Models of Computation", semester: [Semester.FALL], category: [CategoryId.PROGRAMMING_LANGUAGES, CategoryId.THEORY_AND_ALGORITHMS], creditOptions: [3, 4], creditHours: 4 },
+
+    // Scientific Computing - Online Available
+    { id: CourseId.NUMERICAL_ANALYSIS, code: CourseCode.CS_450, name: "Numerical Analysis", semester: [Semester.FALL], category: [CategoryId.SCIENTIFIC_COMPUTING], creditOptions: [3, 4], creditHours: 4 },
+
+    // Security & Privacy - Online Available
+    { id: CourseId.COMPUTER_SECURITY_I, code: CourseCode.CS_461, name: "Computer Security I", semester: [Semester.FALL], category: [CategoryId.SECURITY_AND_PRIVACY], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.COMPUTER_SECURITY_II, code: CourseCode.CS_463, name: "Computer Security II", semester: [Semester.SPRING], category: [CategoryId.SECURITY_AND_PRIVACY], creditOptions: [3, 4], creditHours: 4 },
+
+    // Systems & Networking - Online Available
+    { id: CourseId.DISTRIBUTED_SYSTEMS, code: CourseCode.CS_425, name: "Distributed Systems", semester: [Semester.FALL], category: [CategoryId.SYSTEMS_AND_NETWORKING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.CLOUD_NETWORKING, code: CourseCode.CS_435, name: "Cloud Networking", semester: [Semester.FALL], category: [CategoryId.SYSTEMS_AND_NETWORKING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.INTERNET_OF_THINGS, code: CourseCode.CS_437, name: "Internet of Things", semester: [Semester.FALL, Semester.SPRING], category: [CategoryId.SYSTEMS_AND_NETWORKING], creditOptions: [3, 4], creditHours: 4 },
+    { id: CourseId.CLOUD_COMPUTING_APPLICATIONS, code: CourseCode.CS_498, name: "Cloud Computing Applications", semester: [Semester.SPRING], category: [CategoryId.SYSTEMS_AND_NETWORKING], creditOptions: [3, 4], creditHours: 4 },
+
+    // Advanced Coursework (CS 500-level) - Online Available
+    { id: CourseId.THEORY_AND_PRACTICE_OF_DATA_CURATION, code: CourseCode.CS_513, name: "Theory and Practice of Data Curation", semester: [Semester.SUMMER], category: [CategoryId.ADVANCED_COURSEWORK] },
+    { id: CourseId.PRACTICAL_STATISTICAL_LEARNING, code: CourseCode.CS_598, name: "Practical Statistical Learning", semester: [Semester.FALL], category: [CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 1, courses: { mandatory: [], optional: [CourseId.TEXT_INFORMATION_SYSTEMS, CourseId.INTRODUCTION_TO_DATA_MINING, CourseId.APPLIED_MACHINE_LEARNING, CourseId.COMPUTATIONAL_PHOTOGRAPHY] } } },
+    { id: CourseId.ADVANCED_BAYESIAN_MODELING, code: CourseCode.CS_598, name: "Advanced Bayesian Modeling", semester: [Semester.SPRING], category: [CategoryId.ADVANCED_COURSEWORK] },
+    { id: CourseId.DATA_MINING_CAPSTONE, code: CourseCode.CS_598, name: "Data Mining Capstone", semester: [Semester.SUMMER], category: [CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 2, courses: { mandatory: [CourseId.TEXT_INFORMATION_SYSTEMS, CourseId.INTRODUCTION_TO_DATA_MINING], optional: [] } } },
+    { id: CourseId.CLOUD_COMPUTING_CAPSTONE, code: CourseCode.CS_598, name: "Cloud Computing Capstone", semester: [Semester.FALL], category: [CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 2, courses: { mandatory: [CourseId.CLOUD_COMPUTING_APPLICATIONS], optional: [CourseId.DISTRIBUTED_SYSTEMS, CourseId.CLOUD_NETWORKING, CourseId.INTERNET_OF_THINGS] } } },
+
+    // Electives - Online Available
+    { id: CourseId.FOUNDATIONS_OF_DATA_CURATION, code: CourseCode.CS_598, name: "Foundations of Data Curation", semester: [Semester.FALL], category: [CategoryId.ADVANCED_COURSEWORK] },
+    { id: CourseId.METHODS_OF_APPLIED_STATISTICS, code: CourseCode.STAT_420, name: "Methods of Applied Statistics", semester: [Semester.SUMMER], category: [CategoryId.ELECTIVES] },
+    { id: CourseId.AI_AGENTS_IN_THE_WILD, code: CourseCode.CS_498, name: "AI Agents in the Wild", semester: [Semester.SPRING], category: [CategoryId.ELECTIVES], creditOptions: [3, 4], creditHours: 4 },
+
+
+    // CS 591 Seminars (not available for online students, but included for future reference)
+    { id: CourseId.CS_591_COLLOQUIUM, code: CourseCode.CS_591, name: "CS Colloquium", semester: [], category: [CategoryId.ELECTIVES], creditHours: 1  },
+    { id: CourseId.CS_591_STARTUP_SEMINAR, code: CourseCode.CS_591, name: "Computing Startup Seminar", semester: [], category: [CategoryId.ELECTIVES], creditHours: 1  },
+    { id: CourseId.ADVANCED_SEMINAR, code: CourseCode.CS_591, name: "Other Advanced Seminar", semester: [], category: [CategoryId.ELECTIVES], creditHours: 1 },
+
+    // Placeholder Electives - Pre-approved graduate courses
+    // Graduate (400- and 500-level) coursework from Computer Science, other Grainger College of Engineering Departments,
+    // MATH, STAT, or PHYS are pre-approved as elective courses. All other courses must receive prior approval.
+    { id: CourseId.CS_400_490_ELECTIVE, code: CourseCode.CS_400_490, name: "CS 400-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    { id: CourseId.CS_500_590_ELECTIVE, code: CourseCode.CS_500_590, name: "CS 500-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.MATH_400_ELECTIVE, code: CourseCode.MATH_400, name: "MATH 400-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.MATH_500_ELECTIVE, code: CourseCode.MATH_500, name: "MATH 500-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.STAT_400_ELECTIVE, code: CourseCode.STAT_400, name: "STAT 400-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.STAT_500_ELECTIVE, code: CourseCode.STAT_500, name: "STAT 500-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.PHYS_400_ELECTIVE, code: CourseCode.PHYS_400, name: "PHYS 400-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+    // { id: CourseId.PHYS_500_ELECTIVE, code: CourseCode.PHYS_500, name: "PHYS 500-level Elective", semester: [], category: [CategoryId.ELECTIVES], creditHours: 4 },
+
+    // General Electives: Pre-approved graduate courses
+    // The online MCS program allows the following courses to satisfy the 1 elective requirement:
+    // - CS 400-491: 400-level CS courses generally count toward breadth requirements, but can be counted as electives when appropriate
+    // - CS 498: Special topics and applications courses (must be approved for graduate credit)
+    // - CS 591: Seminars and colloquia (typically require in-person attendance, not available for online students)
+    // - CS 500+: Advanced coursework courses (normally satisfy the 3 advanced coursework requirement)
+    // - MATH, STAT, PHYS, or other Grainger department courses: When pre-approved as graduate-level electives
+    //
+    // Additional Requirements:
+    // - Only 500-level and 400-level (when offered for graduate credit) coursework may be counted toward degree requirements
+    // - A maximum of 4 hours of CS 491 and CS 591 may be applied toward the degree (not available for online students)
+    // - Any course taken for letter grade must have a grade of C or higher
+    // - A grade of B- or higher is required for the Breadth coursework
+    // - The minimum program GPA is 3.0
+  ],
+  tracks: [
+    {
+      id: TrackId.ARTIFICIAL_INTELLIGENCE,
+      name: "Artificial Intelligence",
+      description: "Focus on machine learning, deep learning, and AI applications",
+      requirements: [
+        {
+          name: "AI Courses",
+          required: 3,
+          courseIds: [CourseId.ARTIFICIAL_INTELLIGENCE, CourseId.APPLIED_MACHINE_LEARNING, CourseId.COMPUTATIONAL_PHOTOGRAPHY, CourseId.MACHINE_LEARNING, CourseId.NATURAL_LANGUAGE_PROCESSING, CourseId.DEEP_LEARNING_FOR_HEALTHCARE],
+          description: "Must complete 3 courses from the AI specialty track"
+        }
+      ]
+    },
+    {
+      id: TrackId.DATA_SCIENCE,
+      name: "Data Science",
+      description: "Specialized curriculum for data science with prescribed breadth and advanced coursework",
+      requirements: [] // Special handling - see breadthAreas and advancedCourseIds below
+    } as any, // Type cast due to DataScienceTrack complexity
+    {
+      id: TrackId.GRAPHICS_AND_VISUALIZATION,
+      name: "Graphics and Visualization",
+      description: "Specialized in graphics rendering and data visualization",
+      requirements: [
+        {
+          name: "Graphics and Visualization Courses",
+          required: 3,
+          courseIds: [CourseId.DATA_VISUALIZATION, CourseId.INTERACTIVE_COMPUTER_GRAPHICS, CourseId.COMPUTATIONAL_PHOTOGRAPHY, CourseId.SCIENTIFIC_VISUALIZATION],
+          description: "Must complete 3 courses from the graphics and visualization specialty track"
+        }
+      ]
+    },
+    {
+      id: TrackId.INFORMATION_SYSTEMS,
+      name: "Information Systems",
+      description: "Focus on databases and information management",
+      requirements: [
+        {
+          name: "Information Systems Courses",
+          required: 3,
+          courseIds: [CourseId.TEXT_INFORMATION_SYSTEMS, CourseId.DATABASE_SYSTEMS, CourseId.INTRODUCTION_TO_DATA_MINING, CourseId.THEORY_AND_PRACTICE_OF_DATA_CURATION, CourseId.DATA_MINING_CAPSTONE],
+          description: "Must complete 3 courses from the information systems specialty track"
+        }
+      ]
+    },
+    {
+      id: TrackId.NETWORKED_AND_DISTRIBUTED_SYSTEMS,
+      name: "Networked and Distributed Systems",
+      description: "Focus on distributed systems, cloud computing, and networking",
+      requirements: [
+        {
+          name: "Distributed Systems Courses",
+          required: 3,
+          courseIds: [CourseId.DISTRIBUTED_SYSTEMS, CourseId.CLOUD_NETWORKING, CourseId.CLOUD_COMPUTING_APPLICATIONS, CourseId.CLOUD_COMPUTING_CAPSTONE],
+          description: "Must complete 3 courses from the networked and distributed systems specialty track"
+        }
+      ]
+    },
+    {
+      id: TrackId.SOFTWARE_ENGINEERING,
+      name: "Software Engineering",
+      description: "Focus on software design, engineering practices, and parallel computing",
+      requirements: [
+        {
+          name: "Software Engineering Courses",
+          required: 3,
+          courseIds: [CourseId.PROGRAMMING_LANGUAGES_AND_COMPILERS, CourseId.DISTRIBUTED_SYSTEMS, CourseId.SOFTWARE_ENGINEERING_I, CourseId.PARALLEL_PROGRAMMING],
+          description: "Must complete 3 courses from the software engineering specialty track"
+        }
+      ]
+    }
+  ],
+  dataScience: {
+    id: TrackId.DATA_SCIENCE,
+    name: "Data Science",
+    description: "Specialized curriculum for data science with prescribed breadth and advanced coursework",
+    requirements: [],
+    breadthAreas: [
+      {
+        name: "Machine Learning",
+        required: 1,
+        courseIds: [CourseId.APPLIED_MACHINE_LEARNING, CourseId.COMPUTATIONAL_PHOTOGRAPHY, CourseId.MACHINE_LEARNING, CourseId.NATURAL_LANGUAGE_PROCESSING, CourseId.DEEP_LEARNING_FOR_HEALTHCARE]
+      },
+      {
+        name: "Data Mining",
+        required: 1,
+        courseIds: [CourseId.TEXT_INFORMATION_SYSTEMS, CourseId.DATABASE_SYSTEMS, CourseId.INTRODUCTION_TO_DATA_MINING]
+      },
+      {
+        name: "Data Visualization",
+        required: 1,
+        courseIds: [CourseId.DATA_VISUALIZATION, CourseId.SCIENTIFIC_VISUALIZATION]
+      },
+      {
+        name: "Cloud Computing",
+        required: 1,
+        courseIds: [CourseId.DISTRIBUTED_SYSTEMS, CourseId.CLOUD_NETWORKING, CourseId.INTERNET_OF_THINGS, CourseId.CLOUD_COMPUTING_APPLICATIONS]
+      }
+    ],
+    advancedCourseIds: [CourseId.THEORY_AND_PRACTICE_OF_DATA_CURATION, CourseId.SCIENTIFIC_VISUALIZATION, CourseId.FOUNDATIONS_OF_DATA_CURATION, CourseId.PRACTICAL_STATISTICAL_LEARNING, CourseId.ADVANCED_BAYESIAN_MODELING, CourseId.DEEP_LEARNING_FOR_HEALTHCARE, CourseId.CLOUD_COMPUTING_CAPSTONE, CourseId.DATA_MINING_CAPSTONE],
+    recommendedElectiveIds: [CourseId.INTERACTIVE_COMPUTER_GRAPHICS, CourseId.PROGRAMMING_LANGUAGES_AND_COMPILERS, CourseId.SOFTWARE_ENGINEERING_I, CourseId.NUMERICAL_ANALYSIS, CourseId.COMPUTER_SECURITY_I, CourseId.COMPUTER_SECURITY_II, CourseId.FORMAL_MODELS_OF_COMPUTATION, CourseId.PARALLEL_PROGRAMMING, CourseId.METHODS_OF_APPLIED_STATISTICS]
+  } as any
+};

--- a/src/app/planner/constants/enums.ts
+++ b/src/app/planner/constants/enums.ts
@@ -1,0 +1,150 @@
+/**
+ * Enum definitions for all courses, categories, tracks, and other constants
+ * This file serves as the single source of truth for all identifiers in the planner
+ */
+
+export enum CourseId {
+  // Architecture, Compilers, Parallel Computing
+  PARALLEL_PROGRAMMING = 'prp',
+
+  // Artificial Intelligence
+  ARTIFICIAL_INTELLIGENCE = 'ai440',
+  APPLIED_MACHINE_LEARNING = 'aml',
+  COMPUTATIONAL_PHOTOGRAPHY = 'cph',
+  MACHINE_LEARNING = 'ai446',
+  NATURAL_LANGUAGE_PROCESSING = 'nlp',
+  DEEP_LEARNING_FOR_HEALTHCARE = 'dlh',
+
+  // Database & Information Systems
+  TEXT_INFORMATION_SYSTEMS = 'tis',
+  DATABASE_SYSTEMS = 'dbs',
+  INTRODUCTION_TO_DATA_MINING = 'idm',
+
+  // Interactive Computing
+  DATA_VISUALIZATION = 'dvz',
+  INTERACTIVE_COMPUTER_GRAPHICS = 'icg',
+  SCIENTIFIC_VISUALIZATION = 'svz',
+
+  // Programming Languages, Formal Methods, Software Engineering
+  PROGRAMMING_LANGUAGES_AND_COMPILERS = 'plc',
+  SOFTWARE_ENGINEERING_I = 'swi',
+  FORMAL_MODELS_OF_COMPUTATION = 'fmc',
+
+  // Scientific Computing
+  NUMERICAL_ANALYSIS = 'nma',
+
+  // Security & Privacy
+  COMPUTER_SECURITY_I = 'sec1',
+  COMPUTER_SECURITY_II = 'cse',
+
+  // Systems & Networking
+  DISTRIBUTED_SYSTEMS = 'dst',
+  CLOUD_NETWORKING = 'cnt',
+  INTERNET_OF_THINGS = 'iot',
+  CLOUD_COMPUTING_APPLICATIONS = 'cca',
+
+  // Advanced Coursework (CS 500-level)
+  THEORY_AND_PRACTICE_OF_DATA_CURATION = 'tpd',
+  PRACTICAL_STATISTICAL_LEARNING = 'psl',
+  ADVANCED_BAYESIAN_MODELING = 'adm',
+  DATA_MINING_CAPSTONE = 'dmc',
+  CLOUD_COMPUTING_CAPSTONE = 'ccc',
+
+  // Electives
+  FOUNDATIONS_OF_DATA_CURATION = 'fdoc',
+  METHODS_OF_APPLIED_STATISTICS = 'stat420',
+  AI_AGENTS_IN_THE_WILD = 'aiaw',
+  ADVANCED_SEMINAR = 'ads',
+  CS_591_COLLOQUIUM = 'coll',
+  CS_591_STARTUP_SEMINAR = 'css',
+
+  // Placeholder Electives
+  CS_400_490_ELECTIVE = 'cs400-490',
+  CS_500_590_ELECTIVE = 'cs500-590',
+  MATH_400_ELECTIVE = 'math400',
+  MATH_500_ELECTIVE = 'math500',
+  STAT_400_ELECTIVE = 'stat400',
+  STAT_500_ELECTIVE = 'stat500',
+  PHYS_400_ELECTIVE = 'phys400',
+  PHYS_500_ELECTIVE = 'phys500',
+}
+
+export enum CourseCode {
+  CS_410 = 'CS 410',
+  CS_411 = 'CS 411',
+  CS_412 = 'CS 412',
+  CS_416 = 'CS 416',
+  CS_418 = 'CS 418',
+  CS_421 = 'CS 421',
+  CS_425 = 'CS 425',
+  CS_427 = 'CS 427',
+  CS_435 = 'CS 435',
+  CS_437 = 'CS 437',
+  CS_440 = 'CS 440',
+  CS_441 = 'CS 441',
+  CS_445 = 'CS 445',
+  CS_446 = 'CS 446',
+  CS_447 = 'CS 447',
+  CS_450 = 'CS 450',
+  CS_461 = 'CS 461',
+  CS_463 = 'CS 463',
+  CS_475 = 'CS 475',
+  CS_484 = 'CS 484',
+  CS_498 = 'CS 498',
+  CS_513 = 'CS 513',
+  CS_519 = 'CS 519',
+  CS_591 = 'CS 591',
+  CS_598 = 'CS 598',
+  STAT_420 = 'STAT 420',
+
+  // Placeholder Elective Codes
+  CS_400_490 = 'CS 400-490,498',
+  CS_500_590 = 'CS 500-590,598',
+  MATH_400 = 'MATH 400+',
+  MATH_500 = 'MATH 500+',
+  STAT_400 = 'STAT 400+',
+  STAT_500 = 'STAT 500+',
+  PHYS_400 = 'PHYS 400+',
+  PHYS_500 = 'PHYS 500+',
+}
+
+export enum CategoryId {
+  // Breadth Categories
+  ARCHITECTURE = 'arch-1',
+  ARTIFICIAL_INTELLIGENCE = 'ai-1',
+  DATABASE_AND_INFORMATION_SYSTEMS = 'db-1',
+  INTERACTIVE_COMPUTING = 'ic-1',
+  PROGRAMMING_LANGUAGES = 'pl-1',
+  SCIENTIFIC_COMPUTING = 'sci-1',
+  SECURITY_AND_PRIVACY = 'sec-1',
+  SYSTEMS_AND_NETWORKING = 'sys-1',
+  THEORY_AND_ALGORITHMS = 'thy-1',
+
+  // Special Categories
+  ADVANCED_COURSEWORK = 'adv-1',
+  ELECTIVES = 'elec-1',
+}
+
+export enum TrackId {
+  ARTIFICIAL_INTELLIGENCE = 'ai',
+  DATA_SCIENCE = 'ds',
+  GRAPHICS_AND_VISUALIZATION = 'graphics',
+  INFORMATION_SYSTEMS = 'info-systems',
+  NETWORKED_AND_DISTRIBUTED_SYSTEMS = 'network-dist',
+  SOFTWARE_ENGINEERING = 'software-eng',
+}
+
+export enum Semester {
+  SPRING = 'spring',
+  SUMMER = 'summer',
+  FALL = 'fall',
+}
+
+export const SEMESTER_DISPLAY = {
+  [Semester.SPRING]: 'Spring',
+  [Semester.SUMMER]: 'Summer',
+  [Semester.FALL]: 'Fall',
+};
+
+export const TOTAL_BOXES = 9;
+export const DEFAULT_CREDITS = 4;

--- a/src/app/planner/constants/index.ts
+++ b/src/app/planner/constants/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel export for planner constants
+ * Provides a single entry point for importing all constants
+ */
+
+export * from './enums';
+export * from './course-data.constants';

--- a/src/app/planner/planner.module.ts
+++ b/src/app/planner/planner.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PlannerComponent } from './components/planner.component';
+
+@NgModule({
+  declarations: [
+    PlannerComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  exports: [
+    PlannerComponent
+  ]
+})
+export class PlannerModule { }

--- a/src/app/planner/services/course-data.service.spec.ts
+++ b/src/app/planner/services/course-data.service.spec.ts
@@ -1,0 +1,225 @@
+import { TestBed } from '@angular/core/testing';
+import { CourseDataService, Course, Track, DataScienceTrack } from './course-data.service';
+
+describe('CourseDataService', () => {
+  let service: CourseDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CourseDataService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getCourseData', () => {
+    it('should return course data object', () => {
+      const data = service.getCourseData();
+      expect(data).toBeDefined();
+      expect(data.courses).toBeDefined();
+      expect(data.requirements).toBeDefined();
+      expect(data.tracks).toBeDefined();
+      expect(data.dataScience).toBeDefined();
+    });
+
+    it('should return course data with valid structure', () => {
+      const data = service.getCourseData();
+      expect(Array.isArray(data.courses)).toBe(true);
+      expect(Array.isArray(data.tracks)).toBe(true);
+      expect(data.requirements.total).toBeDefined();
+      expect(data.requirements.total.required).toBeDefined();
+      expect(data.requirements.total.minimum_credit).toBeDefined();
+      expect(Array.isArray(data.requirements.req)).toBe(true);
+    });
+  });
+
+  describe('getCourse', () => {
+    it('should return a course when valid id is provided', () => {
+      const data = service.getCourseData();
+      if (data.courses.length > 0) {
+        const courseId = data.courses[0].id;
+        const course = service.getCourse(courseId);
+        expect(course).toBeDefined();
+        expect(course?.id).toBe(courseId);
+      }
+    });
+
+    it('should return undefined when invalid id is provided', () => {
+      const course = service.getCourse('invalid-course-id-xyz');
+      expect(course).toBeUndefined();
+    });
+
+    it('should return course with all required properties', () => {
+      const data = service.getCourseData();
+      if (data.courses.length > 0) {
+        const course = service.getCourse(data.courses[0].id);
+        expect(course).toBeDefined();
+        if (course) {
+          expect(course.id).toBeDefined();
+          expect(course.code).toBeDefined();
+          expect(course.name).toBeDefined();
+          expect(Array.isArray(course.semester)).toBe(true);
+          expect(Array.isArray(course.category)).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe('getSemesterCourses', () => {
+    it('should return courses for spring semester', () => {
+      const courses = service.getSemesterCourses('spring');
+      expect(Array.isArray(courses)).toBe(true);
+      courses.forEach(course => {
+        expect(course.semester).toContain('spring');
+      });
+    });
+
+    it('should return courses for summer semester', () => {
+      const courses = service.getSemesterCourses('summer');
+      expect(Array.isArray(courses)).toBe(true);
+      courses.forEach(course => {
+        expect(course.semester).toContain('summer');
+      });
+    });
+
+    it('should return courses for fall semester', () => {
+      const courses = service.getSemesterCourses('fall');
+      expect(Array.isArray(courses)).toBe(true);
+      courses.forEach(course => {
+        expect(course.semester).toContain('fall');
+      });
+    });
+
+    it('should return empty array for invalid semester', () => {
+      const courses = service.getSemesterCourses('invalid');
+      expect(Array.isArray(courses)).toBe(true);
+      expect(courses.length).toBe(0);
+    });
+
+    it('should not return courses that do not match the semester', () => {
+      const allCourses = service.getCourseData().courses;
+      const springCourses = service.getSemesterCourses('spring');
+      const fallOnlyCourses = allCourses.filter(c => 
+        c.semester.includes('fall') && !c.semester.includes('spring')
+      );
+      
+      fallOnlyCourses.forEach(fallCourse => {
+        expect(springCourses.find(c => c.id === fallCourse.id)).toBeUndefined();
+      });
+    });
+  });
+
+  describe('getCategoryCourses', () => {
+    it('should return courses for a valid category', () => {
+      const data = service.getCourseData();
+      if (data.requirements.req.length > 0 && data.requirements.req[0].categories.length > 0) {
+        const categoryId = data.requirements.req[0].categories[0].id;
+        const courses = service.getCategoryCourses(categoryId);
+        expect(Array.isArray(courses)).toBe(true);
+        courses.forEach(course => {
+          expect(course.category).toContain(categoryId);
+        });
+      }
+    });
+
+    it('should return empty array for invalid category', () => {
+      const courses = service.getCategoryCourses('invalid-category-xyz');
+      expect(Array.isArray(courses)).toBe(true);
+      expect(courses.length).toBe(0);
+    });
+
+    it('should not return courses that do not match the category', () => {
+      const allCourses = service.getCourseData().courses;
+      const data = service.getCourseData();
+      if (data.requirements.req.length > 0 && data.requirements.req[0].categories.length > 0) {
+        const categoryId = data.requirements.req[0].categories[0].id;
+        const categoryCourses = service.getCategoryCourses(categoryId);
+        const nonCategoryCourses = allCourses.filter(c => !c.category.includes(categoryId));
+        
+        nonCategoryCourses.forEach(nonCatCourse => {
+          expect(categoryCourses.find(c => c.id === nonCatCourse.id)).toBeUndefined();
+        });
+      }
+    });
+  });
+
+  describe('getTracks', () => {
+    it('should return an array of tracks', () => {
+      const tracks = service.getTracks();
+      expect(Array.isArray(tracks)).toBe(true);
+    });
+
+    it('should return tracks with all required properties', () => {
+      const tracks = service.getTracks();
+      tracks.forEach(track => {
+        expect(track.id).toBeDefined();
+        expect(track.name).toBeDefined();
+        expect(track.description).toBeDefined();
+        expect(Array.isArray(track.requirements)).toBe(true);
+      });
+    });
+  });
+
+  describe('getTrack', () => {
+    it('should return a track when valid id is provided', () => {
+      const tracks = service.getTracks();
+      if (tracks.length > 0) {
+        const trackId = tracks[0].id;
+        const track = service.getTrack(trackId);
+        expect(track).toBeDefined();
+        expect(track?.id).toBe(trackId);
+      }
+    });
+
+    it('should return undefined when invalid id is provided', () => {
+      const track = service.getTrack('invalid-track-id-xyz');
+      expect(track).toBeUndefined();
+    });
+  });
+
+  describe('getDataScienceTrack', () => {
+    it('should return data science track', () => {
+      const track = service.getDataScienceTrack();
+      expect(track).toBeDefined();
+      expect(track.id).toBeDefined();
+      expect(track.name).toBeDefined();
+      expect(track.description).toBeDefined();
+      expect(Array.isArray(track.breadthAreas)).toBe(true);
+      expect(Array.isArray(track.advancedCourseIds)).toBe(true);
+      expect(Array.isArray(track.recommendedElectiveIds)).toBe(true);
+    });
+
+    it('should return data science track with valid breadth areas', () => {
+      const track = service.getDataScienceTrack();
+      track.breadthAreas.forEach(area => {
+        expect(area.name).toBeDefined();
+        expect(area.required).toBeDefined();
+        expect(typeof area.required).toBe('number');
+        expect(Array.isArray(area.courseIds)).toBe(true);
+      });
+    });
+
+    it('should return data science track with course IDs that exist', () => {
+      const track = service.getDataScienceTrack();
+      const allCourseIds = service.getCourseData().courses.map(c => c.id);
+      
+      // Check advanced course IDs
+      track.advancedCourseIds.forEach(courseId => {
+        expect(allCourseIds).toContain(courseId);
+      });
+
+      // Check breadth area course IDs
+      track.breadthAreas.forEach(area => {
+        area.courseIds.forEach(courseId => {
+          expect(allCourseIds).toContain(courseId);
+        });
+      });
+
+      // Check recommended elective IDs
+      track.recommendedElectiveIds.forEach(courseId => {
+        expect(allCourseIds).toContain(courseId);
+      });
+    });
+  });
+});

--- a/src/app/planner/services/course-data.service.ts
+++ b/src/app/planner/services/course-data.service.ts
@@ -1,0 +1,116 @@
+/**
+ * Based on UIUC MCS Course Planner (https://github.com/uiucmcs/courseplanner)
+ * Copyright (c) 2021 UIUC MCS Community
+ * Licensed under the MIT License
+ */
+
+import { Injectable } from '@angular/core';
+import { COURSE_DATA } from '../constants';
+
+export interface CourseRequirement {
+  id: string;
+  name: string;
+  ds?: boolean;
+}
+
+export interface RequirementCategory {
+  name: string;
+  required: number;
+  minimum_credit: number;
+  categories: CourseRequirement[];
+}
+
+export interface Prerequisite {
+  minimum: number;
+  courses: {
+    mandatory: string[];
+    optional: string[];
+  };
+}
+
+export interface Course {
+  id: string;
+  code: string;
+  name: string;
+  semester: string[];
+  category: string[];
+  prerequisite?: Prerequisite;
+  creditHours?: number; // Default is 4, can be 3 or 4 for 400-level courses
+  creditOptions?: number[]; // Array of available credit hour options (e.g., [3, 4])
+}
+
+export interface TrackRequirement {
+  name: string;
+  required: number;
+  courseIds: string[];
+  description?: string;
+}
+
+export interface Track {
+  id: string;
+  name: string;
+  description: string;
+  requirements: TrackRequirement[];
+}
+
+export interface DataScienceTrackArea {
+  name: string;
+  required: number;
+  courseIds: string[];
+}
+
+export interface DataScienceTrack extends Track {
+  breadthAreas: DataScienceTrackArea[];
+  advancedCourseIds: string[];
+  recommendedElectiveIds: string[];
+}
+
+export interface CourseData {
+  requirements: {
+    total: {
+      required: number;
+      minimum_credit: number;
+    };
+    req: RequirementCategory[];
+  };
+  courses: Course[];
+  tracks: Track[];
+  dataScience: DataScienceTrack;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CourseDataService {
+  private courseData: CourseData = COURSE_DATA;
+
+  constructor() { }
+
+  getCourseData(): CourseData {
+    return this.courseData;
+  }
+
+  getCourse(id: string): Course | undefined {
+    return this.courseData.courses.find(c => c.id === id);
+  }
+
+  getSemesterCourses(semester: string): Course[] {
+    return this.courseData.courses.filter(c => c.semester.includes(semester));
+  }
+
+  getCategoryCourses(categoryId: string): Course[] {
+    return this.courseData.courses.filter(c => c.category.includes(categoryId));
+  }
+
+  getTracks(): Track[] {
+    return this.courseData.tracks;
+  }
+
+  getTrack(trackId: string): Track | undefined {
+    return this.courseData.tracks.find(t => t.id === trackId);
+  }
+
+  getDataScienceTrack(): DataScienceTrack {
+    return this.courseData.dataScience;
+  }
+}

--- a/src/app/planner/services/planner-logic.service.spec.ts
+++ b/src/app/planner/services/planner-logic.service.spec.ts
@@ -1,0 +1,447 @@
+import { TestBed } from '@angular/core/testing';
+import { PlannerLogicService, SelectionBox, CalculationResult } from './planner-logic.service';
+import { CourseDataService } from './course-data.service';
+
+describe('PlannerLogicService', () => {
+  let service: PlannerLogicService;
+  let courseDataService: CourseDataService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PlannerLogicService);
+    courseDataService = TestBed.inject(CourseDataService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getCategories', () => {
+    it('should return an array of categories', () => {
+      const categories = service.getCategories();
+      expect(Array.isArray(categories)).toBe(true);
+    });
+
+    it('should return categories with required properties', () => {
+      const categories = service.getCategories();
+      categories.forEach(cat => {
+        expect(cat.id).toBeDefined();
+        expect(cat.name).toBeDefined();
+        expect(typeof cat.ds).toBe('boolean');
+        expect(typeof cat.type).toBe('number');
+      });
+    });
+
+    it('should initialize categories from course data requirements', () => {
+      const categories = service.getCategories();
+      const courseData = courseDataService.getCourseData();
+      
+      expect(categories.length).toBeGreaterThan(0);
+      
+      // Check that some category IDs match those in course data
+      const categoryIds = categories.map(c => c.id);
+      const reqCategoryIds: string[] = [];
+      courseData.requirements.req.forEach(r => {
+        r.categories.forEach(c => {
+          reqCategoryIds.push(c.id);
+        });
+      });
+      
+      reqCategoryIds.forEach((id: string) => {
+        expect(categoryIds).toContain(id);
+      });
+    });
+  });
+
+  describe('getCurrentSemester', () => {
+    it('should return a valid semester string', () => {
+      const semester = service.getCurrentSemester();
+      expect(['spring', 'summer', 'fall']).toContain(semester);
+    });
+
+    it('should return spring for January to April', () => {
+      // We can't mock Date easily, but we can test the logic by checking the return value
+      const semester = service.getCurrentSemester();
+      expect(typeof semester).toBe('string');
+      expect(semester.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getSelectionBoxes', () => {
+    it('should generate correct number of selection boxes', () => {
+      const boxes = service.getSelectionBoxes('spring', 2024, 6);
+      expect(boxes.length).toBe(6);
+    });
+
+    it('should start with correct semester and year', () => {
+      const boxes = service.getSelectionBoxes('spring', 2024, 6);
+      expect(boxes[0].semester).toBe('spring');
+      expect(boxes[0].year).toBe(2024);
+      expect(boxes[0].name).toBe('Spring 2024');
+    });
+
+    it('should progress through semesters correctly', () => {
+      const boxes = service.getSelectionBoxes('spring', 2024, 6);
+      expect(boxes[0].semester).toBe('spring');
+      expect(boxes[1].semester).toBe('summer');
+      expect(boxes[2].semester).toBe('fall');
+      expect(boxes[3].semester).toBe('spring');
+    });
+
+    it('should increment year after fall semester', () => {
+      const boxes = service.getSelectionBoxes('spring', 2024, 6);
+      expect(boxes[0].year).toBe(2024);
+      expect(boxes[1].year).toBe(2024);
+      expect(boxes[2].year).toBe(2024);
+      expect(boxes[3].year).toBe(2025);
+    });
+
+    it('should initialize with empty courses array', () => {
+      const boxes = service.getSelectionBoxes('spring', 2024, 3);
+      boxes.forEach(box => {
+        expect(Array.isArray(box.courses)).toBe(true);
+        expect(box.courses.length).toBe(0);
+      });
+    });
+
+    it('should generate correct number of boxes for different total counts', () => {
+      expect(service.getSelectionBoxes('fall', 2023, 1).length).toBe(1);
+      expect(service.getSelectionBoxes('fall', 2023, 5).length).toBe(5);
+      expect(service.getSelectionBoxes('fall', 2023, 12).length).toBe(12);
+    });
+
+    it('should handle different starting semesters', () => {
+      const springBoxes = service.getSelectionBoxes('spring', 2024, 3);
+      const summerBoxes = service.getSelectionBoxes('summer', 2024, 3);
+      const fallBoxes = service.getSelectionBoxes('fall', 2024, 3);
+
+      expect(springBoxes[0].semester).toBe('spring');
+      expect(summerBoxes[0].semester).toBe('summer');
+      expect(fallBoxes[0].semester).toBe('fall');
+    });
+  });
+
+  describe('getCategoryForCourse', () => {
+    it('should return categories for a valid course', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        const categories = service.getCategoryForCourse(courseId);
+        expect(Array.isArray(categories)).toBe(true);
+      }
+    });
+
+    it('should return empty array for invalid course', () => {
+      const categories = service.getCategoryForCourse('invalid-course-xyz');
+      expect(Array.isArray(categories)).toBe(true);
+      expect(categories.length).toBe(0);
+    });
+
+    it('should return categories with id and parent properties', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        const categories = service.getCategoryForCourse(courseId);
+        categories.forEach(cat => {
+          expect(cat.id).toBeDefined();
+          expect(typeof cat.parent).toBe('number');
+        });
+      }
+    });
+  });
+
+  describe('addCourse and removeCourse', () => {
+    beforeEach(() => {
+      // Reset selected courses before each test
+      service.setSelectedCourses([]);
+    });
+
+    it('should add a course to selected list', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        service.addCourse(courseId);
+        expect(service.getSelectedCourses()).toContain(courseId);
+      }
+    });
+
+    it('should not add duplicate courses', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        service.addCourse(courseId);
+        service.addCourse(courseId);
+        const selected = service.getSelectedCourses();
+        const count = selected.filter(id => id === courseId).length;
+        expect(count).toBe(1);
+      }
+    });
+
+    it('should remove a course from selected list', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        service.addCourse(courseId);
+        service.removeCourse(courseId);
+        expect(service.getSelectedCourses()).not.toContain(courseId);
+      }
+    });
+
+    it('should handle removing non-existent course gracefully', () => {
+      const initialLength = service.getSelectedCourses().length;
+      service.removeCourse('non-existent-course-xyz');
+      expect(service.getSelectedCourses().length).toBe(initialLength);
+    });
+
+    it('should maintain other courses when removing one', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length >= 2) {
+        const course1Id = courses[0].id;
+        const course2Id = courses[1].id;
+        service.addCourse(course1Id);
+        service.addCourse(course2Id);
+        service.removeCourse(course1Id);
+        expect(service.getSelectedCourses()).toContain(course2Id);
+        expect(service.getSelectedCourses()).not.toContain(course1Id);
+      }
+    });
+  });
+
+  describe('getSelectedCourses and setSelectedCourses', () => {
+    it('should return array of selected course IDs', () => {
+      const selected = service.getSelectedCourses();
+      expect(Array.isArray(selected)).toBe(true);
+    });
+
+    it('should set selected courses', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length >= 2) {
+        const courseIds = [courses[0].id, courses[1].id];
+        service.setSelectedCourses(courseIds);
+        expect(service.getSelectedCourses()).toEqual(courseIds);
+      }
+    });
+
+    it('should return a copy of selected courses array', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        service.addCourse(courseId);
+        const selected = service.getSelectedCourses();
+        selected.push('new-course');
+        expect(service.getSelectedCourses().length).not.toBe(selected.length);
+      }
+    });
+  });
+
+  describe('setCreditHours and getCreditHours', () => {
+    it('should set custom credit hours for a course', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        service.setCreditHours(courseId, 3);
+        expect(service.getCreditHours(courseId)).toBe(3);
+      }
+    });
+
+    it('should return default 4 credits if not set', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        const credits = service.getCreditHours(courseId);
+        expect(typeof credits).toBe('number');
+        expect(credits).toBeGreaterThan(0);
+      }
+    });
+
+    it('should use course credit hours if specified', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithCredits = courses.find(c => c.creditHours);
+      if (courseWithCredits && courseWithCredits.creditHours) {
+        const credits = service.getCreditHours(courseWithCredits.id);
+        expect(credits).toBe(courseWithCredits.creditHours);
+      }
+    });
+
+    it('should override default with custom credit hours', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        const courseId = courses[0].id;
+        const defaultCredits = service.getCreditHours(courseId);
+        service.setCreditHours(courseId, defaultCredits + 1);
+        expect(service.getCreditHours(courseId)).toBe(defaultCredits + 1);
+      }
+    });
+  });
+
+  describe('calculate', () => {
+    beforeEach(() => {
+      service.setSelectedCourses([]);
+    });
+
+    it('should return a calculation result object', () => {
+      const result = service.calculate();
+      expect(result).toBeDefined();
+      expect(typeof result.total).toBe('number');
+      expect(result.color).toBeDefined();
+      expect(typeof result.breadthComplete).toBe('number');
+      expect(typeof result.breadthNeeded).toBe('number');
+      expect(typeof result.advancedComplete).toBe('number');
+      expect(typeof result.advancedNeeded).toBe('number');
+      expect(typeof result.electivesComplete).toBe('number');
+      expect(typeof result.electivesNeeded).toBe('number');
+    });
+
+    it('should calculate zero credits for no courses', () => {
+      const result = service.calculate();
+      expect(result.total).toBe(0);
+    });
+
+    it('should calculate correct total credits', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length >= 2) {
+        service.addCourse(courses[0].id);
+        service.addCourse(courses[1].id);
+        const result = service.calculate();
+        const expectedCredits = service.getCreditHours(courses[0].id) + service.getCreditHours(courses[1].id);
+        expect(result.total).toBe(expectedCredits);
+      }
+    });
+
+    it('should return color-ok when total is 32 credits', () => {
+      const courses = courseDataService.getCourseData().courses;
+      let totalCredits = 0;
+      let courseIndex = 0;
+      
+      // Add courses until we reach 32 credits
+      while (totalCredits < 32 && courseIndex < courses.length) {
+        const courseId = courses[courseIndex].id;
+        service.addCourse(courseId);
+        totalCredits += service.getCreditHours(courseId);
+        courseIndex++;
+      }
+
+      // Adjust if we overshot
+      if (totalCredits > 32) {
+        service.setSelectedCourses([]);
+        // Try with custom credit hours
+        for (let i = 0; i < 8; i++) {
+          service.addCourse(courses[i].id);
+          service.setCreditHours(courses[i].id, 4);
+        }
+      }
+
+      const result = service.calculate();
+      if (result.total === 32) {
+        expect(result.color).toBe('color-ok');
+      }
+    });
+
+    it('should return color-notok when total is not 32 credits', () => {
+      const courses = courseDataService.getCourseData().courses;
+      if (courses.length > 0) {
+        service.addCourse(courses[0].id);
+        const result = service.calculate();
+        if (result.total !== 32) {
+          expect(result.color).toBe('color-notok');
+        }
+      }
+    });
+
+    it('should track breadth courses correctly', () => {
+      const result = service.calculate();
+      expect(Array.isArray(result.breadthCourses)).toBe(true);
+      expect(result.breadthNeeded).toBe(4);
+      expect(result.breadthComplete).toBeGreaterThanOrEqual(0);
+      expect(result.breadthComplete).toBeLessThanOrEqual(9); // Max 9 breadth areas
+    });
+
+    it('should track advanced courses correctly', () => {
+      const result = service.calculate();
+      expect(Array.isArray(result.advancedCourses)).toBe(true);
+      expect(result.advancedNeeded).toBe(3);
+      expect(result.advancedComplete).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should track electives correctly', () => {
+      const result = service.calculate();
+      expect(Array.isArray(result.electivesCourses)).toBe(true);
+      expect(result.electivesNeeded).toBe(1);
+      expect(result.electivesComplete).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should include category calculations', () => {
+      const result = service.calculate();
+      expect(Array.isArray(result.categories)).toBe(true);
+    });
+  });
+
+  describe('checkPrerequisite', () => {
+    beforeEach(() => {
+      service.setSelectedCourses([]);
+    });
+
+    it('should return valid true for course without prerequisites', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithoutPrereq = courses.find(c => !c.prerequisite || c.prerequisite.minimum === 0);
+      if (courseWithoutPrereq) {
+        const result = service.checkPrerequisite(courseWithoutPrereq.id);
+        expect(result.valid).toBe(true);
+        expect(result.message).toBe('');
+      }
+    });
+
+    it('should return valid false for course with unmet prerequisites', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithPrereq = courses.find(c => c.prerequisite && c.prerequisite.minimum > 0);
+      if (courseWithPrereq) {
+        const result = service.checkPrerequisite(courseWithPrereq.id);
+        expect(result.valid).toBe(false);
+        expect(result.message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should return valid true when mandatory prerequisites are met', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithPrereq = courses.find(c => 
+        c.prerequisite && 
+        c.prerequisite.courses.mandatory.length > 0
+      );
+      
+      if (courseWithPrereq && courseWithPrereq.prerequisite) {
+        // Add all mandatory prerequisites
+        courseWithPrereq.prerequisite.courses.mandatory.forEach(prereqId => {
+          service.addCourse(prereqId);
+        });
+
+        // Add optional prerequisites if needed
+        const mandatoryCount = courseWithPrereq.prerequisite.courses.mandatory.length;
+        const optionalNeeded = courseWithPrereq.prerequisite.minimum - mandatoryCount;
+        for (let i = 0; i < optionalNeeded && i < courseWithPrereq.prerequisite.courses.optional.length; i++) {
+          service.addCourse(courseWithPrereq.prerequisite.courses.optional[i]);
+        }
+
+        const result = service.checkPrerequisite(courseWithPrereq.id);
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it('should include course information in prerequisite message', () => {
+      const courses = courseDataService.getCourseData().courses;
+      const courseWithPrereq = courses.find(c => c.prerequisite && c.prerequisite.minimum > 0);
+      if (courseWithPrereq) {
+        const result = service.checkPrerequisite(courseWithPrereq.id);
+        if (!result.valid) {
+          expect(result.message).toContain(courseWithPrereq.code);
+          expect(result.message).toContain(courseWithPrereq.name);
+        }
+      }
+    });
+
+    it('should handle non-existent course gracefully', () => {
+      const result = service.checkPrerequisite('non-existent-course-xyz');
+      expect(result.valid).toBe(true);
+      expect(result.message).toBe('');
+    });
+  });
+});

--- a/src/app/planner/services/planner-logic.service.ts
+++ b/src/app/planner/services/planner-logic.service.ts
@@ -1,0 +1,295 @@
+/**
+ * Based on UIUC MCS Course Planner (https://github.com/uiucmcs/courseplanner)
+ * Copyright (c) 2021 UIUC MCS Community
+ * Licensed under the MIT License
+ */
+
+import { Injectable } from '@angular/core';
+import { CourseDataService, Course, CourseRequirement } from './course-data.service';
+import { CategoryId, Semester, DEFAULT_CREDITS } from '../constants/enums';
+
+export interface CategoryCalculation {
+  total: number;
+  color: string;
+}
+
+export interface CalculationResult {
+  total: number;
+  color: string;
+  breadthComplete: number;
+  breadthNeeded: number;
+  breadthCourses: string[]; // Course IDs that count toward breadth
+  advancedComplete: number;
+  advancedNeeded: number;
+  advancedCourses: string[]; // Course IDs that count toward advanced
+  electivesComplete: number;
+  electivesNeeded: number;
+  electivesCourses: string[]; // Course IDs that count toward electives
+  categories: CategoryCalculation[];
+}
+
+export interface SelectionBox {
+  name: string;
+  semester: string;
+  year: number;
+  courses: Course[];
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  ds: boolean;
+  type: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PlannerLogicService {
+  private perCredit = 4;
+  private categories: Category[] = [];
+  private selected: string[] = [];
+  private creditHourMap: Map<string, number> = new Map(); // Track credit hours for each course
+
+  constructor(private courseDataService: CourseDataService) {
+    this.initializeCategories();
+  }
+
+  private initializeCategories(): void {
+    const data = this.courseDataService.getCourseData();
+    for (let i = 0; i < data.requirements.req.length; i++) {
+      const r = data.requirements.req[i];
+      for (let j = 0; j < r.categories.length; j++) {
+        const cat: Category = {
+          id: r.categories[j].id,
+          name: r.categories[j].name,
+          ds: r.categories[j].ds || false,
+          type: i
+        };
+        this.categories.push(cat);
+      }
+    }
+  }
+
+  getCategories(): Category[] {
+    return this.categories;
+  }
+
+  getCurrentSemester(): string {
+    const month = new Date().getMonth();
+    if (month <= 3) {
+      return Semester.SPRING;
+    } else if (month <= 6) {
+      return Semester.SUMMER;
+    } else {
+      return Semester.FALL;
+    }
+  }
+
+  getSelectionBoxes(startSemester: string, startYear: number, totalBoxes: number): SelectionBox[] {
+    const sems = [Semester.SPRING, Semester.SUMMER, Semester.FALL];
+    let index = sems.indexOf(startSemester as Semester);
+    let year = startYear;
+    const boxes: SelectionBox[] = [];
+
+    for (let i = 0; i < totalBoxes; i++, index++) {
+      if (index !== 0 && index % 3 === 0) {
+        year++;
+      }
+      const sem = sems[index % 3];
+      const semName = sem.charAt(0).toUpperCase() + sem.slice(1);
+      const l: SelectionBox = {
+        name: `${semName} ${year}`,
+        semester: sem,
+        year: year,
+        courses: []
+      };
+      boxes.push(l);
+    }
+
+    return boxes;
+  }
+
+  getCategoryForCourse(courseId: string): { id: string; parent: number }[] {
+    const course = this.courseDataService.getCourse(courseId);
+    const cats: { id: string; parent: number }[] = [];
+
+    if (course) {
+      for (let i = 0; i < this.categories.length; i++) {
+        if (course.category.includes(this.categories[i].id)) {
+          cats.push({
+            id: this.categories[i].id,
+            parent: this.categories[i].type
+          });
+        }
+      }
+    }
+
+    return cats;
+  }
+
+  addCourse(courseId: string): void {
+    if (!this.selected.includes(courseId)) {
+      this.selected.push(courseId);
+    }
+  }
+
+  removeCourse(courseId: string): void {
+    const index = this.selected.indexOf(courseId);
+    if (index > -1) {
+      this.selected.splice(index, 1);
+    }
+  }
+
+  getSelectedCourses(): string[] {
+    return [...this.selected];
+  }
+
+  setSelectedCourses(courseIds: string[]): void {
+    this.selected = [...courseIds];
+  }
+
+  setCreditHours(courseId: string, credits: number): void {
+    this.creditHourMap.set(courseId, credits);
+  }
+
+  getCreditHours(courseId: string): number {
+    const course = this.courseDataService.getCourse(courseId);
+    if (!course) return 4;
+
+    // If stored in map, use that value
+    if (this.creditHourMap.has(courseId)) {
+      return this.creditHourMap.get(courseId)!;
+    }
+
+    // Otherwise use course default or 4
+    return course.creditHours || 4;
+  }
+
+  calculate(): CalculationResult {
+    const data = this.courseDataService.getCourseData();
+    const courses = data.courses;
+
+    // Track breadth areas covered (one per area)
+    const breadthAreas = new Set<string>();
+    let advancedCount = 0;
+    let electiveCount = 0;
+    let totalCredits = 0;
+
+    // Map breadth categories to their area IDs
+    const breadthCategoryMap: { [key: string]: string } = {
+      [CategoryId.ARCHITECTURE]: 'arch',
+      [CategoryId.ARTIFICIAL_INTELLIGENCE]: 'ai',
+      [CategoryId.DATABASE_AND_INFORMATION_SYSTEMS]: 'db',
+      [CategoryId.INTERACTIVE_COMPUTING]: 'ic',
+      [CategoryId.PROGRAMMING_LANGUAGES]: 'pl',
+      [CategoryId.SCIENTIFIC_COMPUTING]: 'sci',
+      [CategoryId.SECURITY_AND_PRIVACY]: 'sec',
+      [CategoryId.SYSTEMS_AND_NETWORKING]: 'sys',
+      [CategoryId.THEORY_AND_ALGORITHMS]: 'thy'
+    };
+
+    // Arrays to track which courses fulfill each requirement
+    const breadthCourses: string[] = [];
+    const advancedCourses: string[] = [];
+    const electivesCourses: string[] = [];
+
+    // Count courses by type
+    for (const courseId of this.selected) {
+      const course = courses.find(c => c.id === courseId);
+      if (!course) continue;
+
+      totalCredits += this.getCreditHours(courseId);
+
+      // Check if it's an advanced course
+      if (course.category.includes(CategoryId.ADVANCED_COURSEWORK)) {
+        advancedCount++;
+        advancedCourses.push(courseId);
+      }
+
+      // Check for electives
+      if (course.category.includes(CategoryId.ELECTIVES)) {
+        electiveCount++;
+        electivesCourses.push(courseId);
+      }
+
+      // Check for breadth areas (can overlap with advanced or electives)
+      let isBreadth = false;
+      for (const cat of course.category) {
+        if (breadthCategoryMap[cat] && !breadthAreas.has(breadthCategoryMap[cat])) {
+          breadthAreas.add(breadthCategoryMap[cat]);
+          isBreadth = true;
+        }
+      }
+      if (isBreadth) {
+        breadthCourses.push(courseId);
+      }
+    }
+
+    const calc: CalculationResult = {
+      total: totalCredits,
+      color: totalCredits === 32 ? 'color-ok' : 'color-notok',
+      breadthComplete: breadthAreas.size,
+      breadthNeeded: 4,
+      breadthCourses: breadthCourses,
+      advancedComplete: advancedCount,
+      advancedNeeded: 3,
+      advancedCourses: advancedCourses,
+      electivesComplete: electiveCount,
+      electivesNeeded: 1,
+      electivesCourses: electivesCourses,
+      categories: []
+    };
+
+    return calc;
+  }
+
+  checkPrerequisite(courseId: string): { valid: boolean; message: string } {
+    const course = this.courseDataService.getCourse(courseId);
+    if (!course || !course.prerequisite || course.prerequisite.minimum <= 0) {
+      return { valid: true, message: '' };
+    }
+
+    let mandatoryCount = 0;
+    let optionalCount = 0;
+
+    for (const selectedId of this.selected) {
+      if (course.prerequisite.courses.mandatory.includes(selectedId)) {
+        mandatoryCount++;
+      } else if (course.prerequisite.courses.optional.includes(selectedId)) {
+        optionalCount++;
+      }
+    }
+
+    if (
+      mandatoryCount < course.prerequisite.courses.mandatory.length ||
+      mandatoryCount + optionalCount < course.prerequisite.minimum
+    ) {
+      let message = `${course.code} ${course.name} has prerequisite(s).`;
+
+      if (course.prerequisite.courses.mandatory.length > 0) {
+        message += ' Must complete: ';
+        const names: string[] = [];
+        for (const id of course.prerequisite.courses.mandatory) {
+          const c = this.courseDataService.getCourse(id);
+          if (c) names.push(`${c.code} ${c.name}`);
+        }
+        message += names.join(', ') + '.';
+      }
+
+      if (course.prerequisite.courses.mandatory.length < course.prerequisite.minimum) {
+        message += ` Complete any ${course.prerequisite.minimum - course.prerequisite.courses.mandatory.length} from: `;
+        const names: string[] = [];
+        for (const id of course.prerequisite.courses.optional) {
+          const c = this.courseDataService.getCourse(id);
+          if (c) names.push(`${c.code} ${c.name}`);
+        }
+        message += names.join(', ') + '.';
+      }
+
+      return { valid: false, message };
+    }
+
+    return { valid: true, message: '' };
+  }
+}

--- a/src/app/services/theme/theme.service.spec.ts
+++ b/src/app/services/theme/theme.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { ThemeService } from './theme.service';
+
+describe('ThemeService', () => {
+  let service: ThemeService;
+  let localStorageMock: { [key: string]: string };
+
+  beforeEach(() => {
+    // Mock localStorage
+    localStorageMock = {};
+    spyOn(localStorage, 'getItem').and.callFake((key: string) => localStorageMock[key] || null);
+    spyOn(localStorage, 'setItem').and.callFake((key: string, value: string) => {
+      localStorageMock[key] = value;
+    });
+    
+    // Mock matchMedia
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jasmine.createSpy('matchMedia').and.returnValue({
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: jasmine.createSpy('addEventListener'),
+        removeEventListener: jasmine.createSpy('removeEventListener')
+      })
+    });
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ThemeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize with light theme by default when no preference is saved', () => {
+    expect(service.isDarkMode()).toBe(false);
+  });
+
+  it('should load saved theme preference from localStorage', () => {
+    localStorageMock['uiuc-mcs-theme'] = 'dark';
+    service = TestBed.inject(ThemeService);
+    expect(service.isDarkMode()).toBe(true);
+  });
+
+  it('should toggle theme from light to dark', () => {
+    service.isDarkMode.set(false);
+    service.toggleTheme();
+    expect(service.isDarkMode()).toBe(true);
+    expect(localStorage.setItem).toHaveBeenCalledWith('uiuc-mcs-theme', 'dark');
+  });
+
+  it('should toggle theme from dark to light', () => {
+    service.isDarkMode.set(true);
+    service.toggleTheme();
+    expect(service.isDarkMode()).toBe(false);
+    expect(localStorage.setItem).toHaveBeenCalledWith('uiuc-mcs-theme', 'light');
+  });
+
+  it('should add dark-theme class to body when dark mode is enabled', () => {
+    service.isDarkMode.set(false);
+    service.toggleTheme();
+    expect(document.body.classList.contains('dark-theme')).toBe(true);
+  });
+
+  it('should remove dark-theme class from body when light mode is enabled', () => {
+    document.body.classList.add('dark-theme');
+    service.isDarkMode.set(true);
+    service.toggleTheme();
+    expect(document.body.classList.contains('dark-theme')).toBe(false);
+  });
+
+  it('should use system preference when no saved preference exists', () => {
+    (window.matchMedia as jasmine.Spy).and.returnValue({
+      matches: true,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: jasmine.createSpy('addEventListener'),
+      removeEventListener: jasmine.createSpy('removeEventListener')
+    });
+    service = TestBed.inject(ThemeService);
+    expect(service.isDarkMode()).toBe(true);
+  });
+});

--- a/src/app/services/theme/theme.service.ts
+++ b/src/app/services/theme/theme.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly THEME_KEY = 'uiuc-mcs-theme';
+  isDarkMode = signal<boolean>(false);
+
+  constructor() {
+    // Load saved theme preference or use system preference
+    const savedTheme = localStorage.getItem(this.THEME_KEY);
+    if (savedTheme !== null) {
+      this.isDarkMode.set(savedTheme === 'dark');
+    } else {
+      // Check system preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      this.isDarkMode.set(prefersDark);
+    }
+    this.applyTheme();
+  }
+
+  toggleTheme(): void {
+    this.isDarkMode.update(dark => !dark);
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    const theme = this.isDarkMode() ? 'dark' : 'light';
+    localStorage.setItem(this.THEME_KEY, theme);
+    
+    // Apply theme class to body
+    if (this.isDarkMode()) {
+      document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+    }
+  }
+}

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,0 +1,38 @@
+// @ts-check
+/** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
+const config = {
+  _comment:
+    "This config was generated using 'stryker init'. Please take a look at: https://stryker-mutator.io/docs/stryker-js/configuration/ for more information.",
+  packageManager: 'npm',
+  reporters: ['html', 'clear-text', 'progress', 'dashboard'],
+  testRunner: 'karma',
+  testRunner_comment:
+    'More information about the karma test runner at: https://stryker-mutator.io/docs/stryker-js/karma-runner',
+  karma: {
+    configFile: 'karma.conf.js',
+    projectType: 'angular-cli',
+    config: {
+      browsers: ['ChromeHeadless']
+    }
+  },
+  coverageAnalysis: 'perTest',
+  mutate: [
+    'src/app/planner/**/*.ts',
+    '!src/app/planner/**/*.spec.ts',
+    '!src/app/planner/**/*.module.ts',
+    '!src/app/planner/constants/*.ts'
+  ],
+  checkers: ['typescript'],
+  tsconfigFile: 'tsconfig.json',
+  thresholds: { high: 80, low: 60, break: 50 },
+  timeoutMS: 60000,
+  timeoutFactor: 2,
+  tempDirName: 'stryker-tmp',
+  cleanTempDir: true,
+  concurrency: 4,
+  htmlReporter: {
+    fileName: 'mutation-report.html'
+  }
+};
+
+export default config;


### PR DESCRIPTION
## Overview

This adds a planner to help students map out their MCS/MCS-DS degree requirements, adds new courses: [Spring 2026 Student Webinar.pdf](https://github.com/user-attachments/files/23468406/Spring.2026.Student.Webinar.pdf)

## Technical Changes

- New `/planner` route with dedicated module under `src/app/planner/`
- Includes `PlannerComponent`, `CategoryBrowserComponent`, and supporting services
- Unit tests (~90% coverage)
- Added Stryker config for mutation testing

## License
This feature is adapted from the [UIUC MCS Course Planner](https://github.com/uiucmcs/courseplanner) (MIT licensed). MIT attribution headers are included in the source files, and the full license text is in `THIRD_PARTY_LICENSES.md`. This is compatible with the project's AGPLv3 license.
