### PR TITLE
Issue #16 - add three new courses

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -60,6 +60,9 @@ function createNotFoundPage(dir, options, logger) {
             'CS-461-Computer-Security-I',
             'CS-475-Formal-Models-of-Computation',
             'CS-591-CS-Colloquium',
+            'CS-498-AI-Agents-in-the-Wild',
+            'CS-440-Artificial-Intelligence',
+            'CS-576-Topics-in-Automated-Deduction',
         ]
         const directory = path.join(dir, 'courses')
         logger.info(`directory = ${directory}`)

--- a/src/app/planner/constants/course-data.constants.ts
+++ b/src/app/planner/constants/course-data.constants.ts
@@ -97,6 +97,7 @@ export const COURSE_DATA: CourseData = {
     { id: CourseId.ADVANCED_BAYESIAN_MODELING, code: CourseCode.CS_598, name: "Advanced Bayesian Modeling", semester: [Semester.SPRING], category: [CategoryId.ADVANCED_COURSEWORK] },
     { id: CourseId.DATA_MINING_CAPSTONE, code: CourseCode.CS_598, name: "Data Mining Capstone", semester: [Semester.SUMMER], category: [CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 2, courses: { mandatory: [CourseId.TEXT_INFORMATION_SYSTEMS, CourseId.INTRODUCTION_TO_DATA_MINING], optional: [] } } },
     { id: CourseId.CLOUD_COMPUTING_CAPSTONE, code: CourseCode.CS_598, name: "Cloud Computing Capstone", semester: [Semester.FALL], category: [CategoryId.ADVANCED_COURSEWORK], prerequisite: { minimum: 2, courses: { mandatory: [CourseId.CLOUD_COMPUTING_APPLICATIONS], optional: [CourseId.DISTRIBUTED_SYSTEMS, CourseId.CLOUD_NETWORKING, CourseId.INTERNET_OF_THINGS] } } },
+    { id: CourseId.TOPICS_IN_AUTOMATED_DEDUCTION, code: CourseCode.CS_576, name: "Topics in Automated Deduction", semester: [Semester.SPRING], category: [CategoryId.ADVANCED_COURSEWORK], creditHours: 4 },
 
     // Electives - Online Available
     { id: CourseId.FOUNDATIONS_OF_DATA_CURATION, code: CourseCode.CS_598, name: "Foundations of Data Curation", semester: [Semester.FALL], category: [CategoryId.ADVANCED_COURSEWORK] },

--- a/src/app/planner/constants/enums.ts
+++ b/src/app/planner/constants/enums.ts
@@ -57,6 +57,7 @@ export enum CourseId {
   ADVANCED_SEMINAR = 'ads',
   CS_591_COLLOQUIUM = 'coll',
   CS_591_STARTUP_SEMINAR = 'css',
+  TOPICS_IN_AUTOMATED_DEDUCTION = 'tad',
 
   // Placeholder Electives
   CS_400_490_ELECTIVE = 'cs400-490',
@@ -93,6 +94,7 @@ export enum CourseCode {
   CS_498 = 'CS 498',
   CS_513 = 'CS 513',
   CS_519 = 'CS 519',
+  CS_576 = 'CS 576',
   CS_591 = 'CS 591',
   CS_598 = 'CS 598',
   STAT_420 = 'STAT 420',

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -39,4 +39,7 @@
 <url><loc>https://uiucmcs.org/courses/CS-427-Software-Engineering-I</loc><lastmod>2022-03-16T11:10:10+00:00</lastmod></url>
 <url><loc>https://uiucmcs.org/courses/CS-410-Text-Information-Systems</loc><lastmod>2022-03-16T11:10:10+00:00</lastmod></url>
 <url><loc>https://uiucmcs.org/courses/CS-513-Theory-and-Practice-of-Data-Cleaning</loc><lastmod>2022-03-16T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-498-AI-Agents-in-the-Wild</loc><lastmod>2026-03-27T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-440-Artificial-Intelligence</loc><lastmod>2026-03-27T11:10:10+00:00</lastmod></url>
+<url><loc>https://uiucmcs.org/courses/CS-576-Topics-in-Automated-Deduction</loc><lastmod>2026-03-27T11:10:10+00:00</lastmod></url>
 </urlset>


### PR DESCRIPTION
This PR adds three courses (described in issue #16):

- CS 440 Artificial Intelligence
- CS 498 AI Agents in the Wild
- CS 576 Topics in Automated Deduction

CS 440 appears to be offered in Fall and Spring.
Syllabus: https://courses.grainger.illinois.edu/cs440/fa2025/syllabus.html

CS 498 AI Agents in the Wild appears to be offered in Fall and Spring.
I wasn't able to locate a sample syllabus.

CS 576 Topics in Automated Deduction is offered in Spring.
Syllabus: https://courses.grainger.illinois.edu/CS576/sp2026/policy.html

CS 440 and CS 498 were already partially added to the code base, so I didn't need to update `src/app/planner/constants/course-data.constants.ts` nor `src/app/planner/constants/enums.ts` for those two courses.


@lookman-olowo @djoldman If these code changes look good to you, do you know what the next steps are to get these courses added into the database? Thank you!